### PR TITLE
Add Inverted screen setting for Waveshare ESP32-S3-RLCD-4.2

### DIFF
--- a/components/display/display_rlcd.cpp
+++ b/components/display/display_rlcd.cpp
@@ -28,6 +28,18 @@ static int s_rst_pin = -1;
 static uint16_t *s_pixel_index_lut = NULL;  /* width * height entries */
 static uint8_t  *s_pixel_bit_lut   = NULL;  /* width * height entries */
 
+/* Runtime "Inverted screen" toggle (Settings menu, persisted in NVS by
+ * the editor). When set, display_flush() sends the bitwise complement
+ * of the framebuffer instead of the framebuffer itself, so pixels that
+ * are normally "active" (ink, bit=0 -- see display_set_pixel) show the
+ * background and vice versa. s_disp_buf itself always keeps holding
+ * the un-inverted logical pixel state so toggling this does not
+ * require re-rendering anything -- just a fresh flush. s_invert_buf is
+ * a same-size PSRAM scratch buffer that holds the complemented bytes
+ * for the duration of the SPI send. */
+static bool     s_invert     = false;
+static uint8_t *s_invert_buf = NULL;
+
 static void init_landscape_lut(int width, int height)
 {
     int h4 = height / 4;
@@ -114,6 +126,10 @@ extern "C" void display_init(int mosi, int sck, int dc, int cs, int rst,
     s_disp_buf = (uint8_t *)heap_caps_malloc(s_disp_len, MALLOC_CAP_SPIRAM);
     assert(s_disp_buf);
 
+    /* Scratch buffer for the "Inverted screen" option; see s_invert. */
+    s_invert_buf = (uint8_t *)heap_caps_malloc(s_disp_len, MALLOC_CAP_SPIRAM);
+    assert(s_invert_buf);
+
     /* Allocate and initialise LUTs in PSRAM */
     int total_pixels = width * height;
     s_pixel_index_lut = (uint16_t *)heap_caps_malloc(total_pixels * sizeof(uint16_t), MALLOC_CAP_SPIRAM);
@@ -183,7 +199,20 @@ extern "C" void display_flush(void)
     send_command(0x2A); send_data(0x12); send_data(0x2A);
     send_command(0x2B); send_data(0x00); send_data(0xC7);
     send_command(0x2C);
-    send_buffer(s_disp_buf, s_disp_len);
+    if (s_invert) {
+        for (int i = 0; i < s_disp_len; i++)
+            s_invert_buf[i] = (uint8_t)~s_disp_buf[i];
+        send_buffer(s_invert_buf, s_disp_len);
+    } else {
+        send_buffer(s_disp_buf, s_disp_len);
+    }
+}
+
+extern "C" void display_set_invert(bool on)
+{
+    if (s_invert == on) return;
+    s_invert = on;
+    display_flush();
 }
 
 extern "C" void display_full_refresh(void)

--- a/components/display/include/display.h
+++ b/components/display/include/display.h
@@ -275,6 +275,23 @@ typedef struct {
  */
 void display_set_backlight(int percent);
 
+/*
+ * Toggle a full visual inversion of the panel: pixels that would
+ * normally render "active" (drawn / ink) show the background instead,
+ * and vice versa. The underlying framebuffer content (as written by
+ * display_set_pixel / display_clear) is unchanged -- only what gets
+ * sent to the panel is affected, so toggling this does not require
+ * re-rendering the LVGL widget tree. The call applies immediately
+ * (it triggers its own display_flush()), so the caller does not need
+ * to flush separately.
+ *
+ * Implemented by display_rlcd.cpp (Waveshare ESP32-S3-RLCD-4.2); gated
+ * behind CONFIG_DRAFTLING_DISPLAY_CAN_INVERT in the editor's F1 ->
+ * Settings menu. Not implemented (and never called) on other
+ * backends.
+ */
+void display_set_invert(bool on);
+
 void display_axs15231b_init(const display_axs15231b_config_t *cfg);
 
 /*

--- a/components/editor/editor_ui.cpp
+++ b/components/editor/editor_ui.cpp
@@ -484,6 +484,40 @@ static void save_rotate180_to_nvs(void)
 }
 #endif  /* CONFIG_DRAFTLING_DISPLAY_CAN_ROTATE */
 
+#if defined(CONFIG_DRAFTLING_DISPLAY_CAN_INVERT)
+/* ---- Inverted screen ----
+ * Toggled from the F1 -> Settings menu and persisted in NVS. When
+ * enabled, active (drawn / ink) pixels show the background and
+ * inactive pixels show the text -- a full visual invert, applied by
+ * display_set_invert() at flush time without touching the framebuffer
+ * or the LVGL widget tree. Currently only offered on the Waveshare
+ * ESP32-S3-RLCD-4.2 (see display_rlcd.cpp). */
+#define NVS_KEY_INVERT "invert"
+static bool s_invert = false;
+
+static void load_invert_from_nvs(void)
+{
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS_EDITOR, NVS_READONLY, &h) == ESP_OK) {
+        uint8_t v = 0;
+        if (nvs_get_u8(h, NVS_KEY_INVERT, &v) == ESP_OK) {
+            s_invert = (v != 0);
+        }
+        nvs_close(h);
+    }
+}
+
+static void save_invert_to_nvs(void)
+{
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS_EDITOR, NVS_READWRITE, &h) == ESP_OK) {
+        nvs_set_u8(h, NVS_KEY_INVERT, s_invert ? 1 : 0);
+        nvs_commit(h);
+        nvs_close(h);
+    }
+}
+#endif  /* CONFIG_DRAFTLING_DISPLAY_CAN_INVERT */
+
 /* ---- Append-only editing ----
  * Toggled from the F1 -> Settings menu and persisted in NVS. When
  * active, existing text can no longer be deleted or edited: Backspace,
@@ -3063,11 +3097,18 @@ static int find_timeout_option(uint32_t sec)
 #define SETTINGS_IDX_ROTATE   (-1)
 #define _SETTINGS_NEXT_AFTER_ROTATE (_SETTINGS_NEXT_AFTER_THEME + 0)
 #endif
-#define SETTINGS_IDX_APPEND_ONLY (_SETTINGS_NEXT_AFTER_ROTATE + 0)
-#define SETTINGS_IDX_SLEEP    (_SETTINGS_NEXT_AFTER_ROTATE + 1)
-#define SETTINGS_IDX_RESET    (_SETTINGS_NEXT_AFTER_ROTATE + 2)
-#define SETTINGS_IDX_BACK     (_SETTINGS_NEXT_AFTER_ROTATE + 3)
-#define SETTINGS_ITEM_COUNT   (_SETTINGS_NEXT_AFTER_ROTATE + 4)
+#if defined(CONFIG_DRAFTLING_DISPLAY_CAN_INVERT)
+#define SETTINGS_IDX_INVERT   (_SETTINGS_NEXT_AFTER_ROTATE + 0)
+#define _SETTINGS_NEXT_AFTER_INVERT (_SETTINGS_NEXT_AFTER_ROTATE + 1)
+#else
+#define SETTINGS_IDX_INVERT   (-1)
+#define _SETTINGS_NEXT_AFTER_INVERT (_SETTINGS_NEXT_AFTER_ROTATE + 0)
+#endif
+#define SETTINGS_IDX_APPEND_ONLY (_SETTINGS_NEXT_AFTER_INVERT + 0)
+#define SETTINGS_IDX_SLEEP    (_SETTINGS_NEXT_AFTER_INVERT + 1)
+#define SETTINGS_IDX_RESET    (_SETTINGS_NEXT_AFTER_INVERT + 2)
+#define SETTINGS_IDX_BACK     (_SETTINGS_NEXT_AFTER_INVERT + 3)
+#define SETTINGS_ITEM_COUNT   (_SETTINGS_NEXT_AFTER_INVERT + 4)
 
 static void refresh_settings_items(void)
 {
@@ -3117,6 +3158,13 @@ static void refresh_settings_items(void)
     /* Runtime 180-degree display flip */
     snprintf(buf, sizeof(buf), "Rotate 180: %s",
              s_rotate180 ? "on" : "off");
+    lv_list_add_btn(s_settings_list, NULL, buf);
+#endif
+
+#if defined(CONFIG_DRAFTLING_DISPLAY_CAN_INVERT)
+    /* Inverted screen */
+    snprintf(buf, sizeof(buf), "Inverted screen: %s",
+             s_invert ? "on" : "off");
     lv_list_add_btn(s_settings_list, NULL, buf);
 #endif
 
@@ -3307,6 +3355,18 @@ static void settings_activate_item(int idx)
         s_rotate180 = !s_rotate180;
         save_rotate180_to_nvs();
         draftling_lvgl_port_set_flip180(s_rotate180);
+        refresh_settings_items();
+#endif
+#if defined(CONFIG_DRAFTLING_DISPLAY_CAN_INVERT)
+    } else if (idx == SETTINGS_IDX_INVERT) {
+        /* Toggle the inverted-screen option. Applied immediately so
+         * the user sees the new polarity without leaving the menu;
+         * persisted in NVS and re-applied at boot. display_set_invert()
+         * only changes what display_flush() sends to the panel, so no
+         * repaint of the LVGL widget tree is needed. */
+        s_invert = !s_invert;
+        save_invert_to_nvs();
+        display_set_invert(s_invert);
         refresh_settings_items();
 #endif
     } else if (idx == SETTINGS_IDX_APPEND_ONLY) {
@@ -6528,6 +6588,16 @@ extern "C" void editor_ui_init(void)
     load_rotate180_from_nvs();
     if (s_rotate180) {
         draftling_lvgl_port_set_flip180(true);
+    }
+#endif
+
+#if defined(CONFIG_DRAFTLING_DISPLAY_CAN_INVERT)
+    /* Restore the persisted inverted-screen option and apply it now
+     * that the panel has been initialized (display_set_invert() sends
+     * a flush of the current framebuffer under the restored polarity). */
+    load_invert_from_nvs();
+    if (s_invert) {
+        display_set_invert(true);
     }
 #endif
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -285,6 +285,20 @@ config DRAFTLING_DISPLAY_CAN_ROTATE
     default y if DRAFTLING_DISPLAY_RGB
     default n
 
+# DRAFTLING_DISPLAY_CAN_INVERT enables a runtime "Inverted screen" entry
+# in the F1 -> Settings menu (persisted in NVS), offered on boards whose
+# display backend implements a software pixel-polarity flip in its
+# display_flush() path. When enabled, pixels that would normally show
+# as "active" (drawn / ink) show the background instead, and vice
+# versa -- a full visual invert, akin to a dark-mode toggle on a panel
+# that has no native inversion command wired up to the editor. Currently
+# only the Waveshare ESP32-S3-RLCD-4.2 (display_rlcd.cpp complements the
+# framebuffer bytes at flush time when the option is on).
+config DRAFTLING_DISPLAY_CAN_INVERT
+    bool
+    default y if DRAFTLING_DISPLAY_RLCD
+    default n
+
 # DRAFTLING_DISPLAY_EPD is set automatically when the selected
 # board has an electronic-paper panel. Code that has to be aware
 # of e-paper specifics (slow refresh, no blinking cursor, white-on-


### PR DESCRIPTION
## Summary
- Adds an "Inverted screen" entry to the F1 -> Settings menu on the Waveshare ESP32-S3-RLCD-4.2. When enabled, active pixels show the background and inactive pixels show the text.
- Implemented as a bitwise complement of the framebuffer applied at `display_flush()` time in `display_rlcd.cpp`, so toggling it does not require re-rendering the LVGL widget tree.
- New `DRAFTLING_DISPLAY_CAN_INVERT` Kconfig symbol (auto-enabled for `DRAFTLING_DISPLAY_RLCD`) gates the menu entry, mirroring the existing `DRAFTLING_DISPLAY_CAN_ROTATE` pattern for other per-board settings.
- Setting is persisted in NVS and restored on boot.

## Test plan
- [x] `idf.py --preset waveshare_rlcd42 build` completes successfully.
- [ ] Flash to hardware and verify the "Inverted screen" toggle in F1 -> Settings visually swaps text/background and persists across a reboot.

https://claude.ai/code/session_012khhbimfYTt6wXMAkRbhKD