### PR TITLE
Add support for Elecrow CrowPanel ESP32-S3 5.79in E-Paper HMI Display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ card).
 | Freenove FNK0104A | 2.8-inch ILI9341 color LCD, 320x240, no touch |
 | Freenove FNK0104B | 2.8-inch ILI9341 color LCD, 320x240, FT6336U touch |
 | Freenove FNK0104S | 4.0-inch ST7796 color LCD, 480x320, FT6336U touch |
+| Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI | 5.79-inch e-paper (SSD1683 x2), 792x272, no touch |
 
 UC8179-based panels (Seeed Studio reTerminal E1001 and the Waveshare
 E-Paper Driver HAT) were previously supported but have been removed:
@@ -260,6 +261,26 @@ Per-board display backends behind a single C API:
   row-by-row across multiple queued `tx_color()` calls previously
   raced with the async DMA hardware, corrupting the lower portion of
   the screen once the transaction queue filled up.
+- **display_ssd1683.cpp** -- from-scratch dual-controller SPI
+  e-paper backend for the Elecrow CrowPanel ESP32-S3 5.79" E-Paper
+  HMI Display, gated on `CONFIG_DRAFTLING_DISPLAY_SSD1683`. The
+  792x272 panel is built from two SSD1683 driver chips, one per half
+  (a "slave" driving columns 0-399 and a "master" driving columns
+  392-791, differentiated purely by command set on a shared SPI
+  bus, every slave command being the master's command `+0x80`); every
+  refresh rewrites each chip's *entire* RAM window (not just the
+  dirty rectangle -- narrower windowing was found unreliable on real
+  hardware) from a 1-bpp PSRAM framebuffer. The master/slave
+  RAM-window addressing math (including the master's inverted
+  X-address counting and the seam-alignment special case) originates
+  from the community ESPHome driver at
+  github.com/samperk1/esphome-crowpanel-579. A single Master
+  Activation trigger on this panel can leave an incomplete pixel
+  transition regardless of waveform or RAM content; `display_flush()`
+  runs both the full and partial refresh paths twice, back-to-back, to
+  reliably complete it (matching what pressing Ctrl+R always did) --
+  see HARDWARE.md's CrowPanel section and PR #47 for the full
+  investigation.
 
 The component's `idf_component.yml` declares the `vroland/epdiy`
 dependency required by both e-paper backends; the source files
@@ -900,14 +921,23 @@ ESP32-S3-only (`depends on IDF_TARGET_ESP32S3`):
 - **DRAFTLING_MODEL_FREENOVE_FNK0104S** -- Freenove FNK0104S: 4.0"
   ST7796 color SPI LCD, 480x320, with an on-board FT6336U I2C touch
   controller. *Requires ESP32-S3.*
+- **DRAFTLING_MODEL_ELECROW_CROWPANEL_579** -- Elecrow CrowPanel
+  ESP32-S3 5.79" E-Paper HMI Display: 792x272 black/white e-paper
+  panel built from two SSD1683 controllers over plain SPI, driven by
+  `components/display/display_ssd1683.cpp`. On-board MicroSD on its
+  own SPI bus. Menu button (GPIO2) is the deep-sleep wake source and
+  doubles as F1 / forget-keyboards; Back button + a 3-way dial
+  switch (Up/Down/OK) provide full menu navigation without a
+  keyboard. No on-board battery monitor. Added without on-hardware
+  testing; see HARDWARE.md. *Requires ESP32-S3.*
 
 The hardware-model selection drives two non-prompted `int` symbols
 consumed in `main/app_config.h` as `DISPLAY_WIDTH` / `DISPLAY_HEIGHT`:
 
 - **DRAFTLING_DISPLAY_WIDTH** -- 400 (RLCD), 960 (PaperS3), 320
-  (FNK0104A/B), 480 (FNK0104S).
+  (FNK0104A/B), 480 (FNK0104S), 792 (Elecrow CrowPanel 5.79").
 - **DRAFTLING_DISPLAY_HEIGHT** -- 300 (RLCD), 540 (PaperS3), 240
-  (FNK0104A/B), 320 (FNK0104S).
+  (FNK0104A/B), 320 (FNK0104S), 272 (Elecrow CrowPanel 5.79").
 
 Both symbols are non-prompted (no menuconfig entry); to support a
 new board with a different resolution, add a model `config` block
@@ -930,9 +960,10 @@ in C / C++ code:
 | Symbol | Purpose | Set by |
 |--------|---------|--------|
 | DRAFTLING_DISPLAY_RLCD            | Selects `display_rlcd.cpp`        | RLCD-4.2 |
-| DRAFTLING_DISPLAY_EPD             | Gates EPD-only options (BLACK_BACKGROUND, full-refresh interval) and the editor's no-blink cursor / 120 ms flush debounce | PaperS3, LilyGO T5 E-Paper S3 Pro / Pro Lite |
+| DRAFTLING_DISPLAY_EPD             | Gates EPD-only options (BLACK_BACKGROUND, full-refresh interval) and the editor's no-blink cursor / 120 ms flush debounce | PaperS3, LilyGO T5 E-Paper S3 Pro / Pro Lite, Elecrow CrowPanel 5.79" |
 | DRAFTLING_DISPLAY_EPDIY           | Selects `display_epdiy.cpp` (with `epd_board_v7` for LilyGO T5 or the in-tree `epd_board_papers3` for PaperS3) and pulls in the `vroland/epdiy` managed component | PaperS3, LilyGO T5 E-Paper S3 Pro / Pro Lite |
 | DRAFTLING_EPDIY_BOARD_PAPERS3     | Switches `display_epdiy.cpp` to the PaperS3 board definition (no VCOM, no shared I2C) | PaperS3 |
+| DRAFTLING_DISPLAY_SSD1683         | Selects `display_ssd1683.cpp` (dual-controller plain-SPI e-paper backend) | Elecrow CrowPanel 5.79" |
 | DRAFTLING_DISPLAY_AXS15231B       | Selects `display_axs15231b.cpp`   | Touch-LCD-3.49, JC3248W535 |
 | DRAFTLING_DISPLAY_ILI9341         | Selects `display_ili9341.cpp` (shared ILI9341/ST7796 SPI backend) with the ILI9341 init sequence | Freenove FNK0104A / FNK0104B |
 | DRAFTLING_DISPLAY_ST7796          | Selects `display_ili9341.cpp` with the ST7796 init sequence | Freenove FNK0104S |
@@ -1027,7 +1058,8 @@ supported board (`waveshare_rlcd42`, `m5stack_papers3`,
 `lilygo_t5_epd_s3_pro`, `lilygo_t5_epd_s3_pro_h752`,
 `waveshare_touch_lcd_349`, `m5stack_tab5`, `jc3248w535`,
 `sunton_8048s070`, `sunton_8048s043`, `waveshare_touch_lcd_7`,
-`freenove_fnk0104a`, `freenove_fnk0104b`, `freenove_fnk0104s`). Each
+`freenove_fnk0104a`, `freenove_fnk0104b`, `freenove_fnk0104s`,
+`elecrow_crowpanel_579`). Each
 preset points `SDKCONFIG_DEFAULTS` at `sdkconfig.defaults` plus its own
 `sdkconfig.defaults.<board>` file in the repository root (which sets
 `CONFIG_IDF_TARGET` and the board's `CONFIG_DRAFTLING_MODEL_*` option),

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -117,6 +117,15 @@
                 "SDKCONFIG_DEFAULTS": "sdkconfig.defaults;sdkconfig.defaults.freenove_fnk0104s",
                 "SDKCONFIG": "build/freenove_fnk0104s/sdkconfig"
             }
+        },
+        {
+            "name": "elecrow_crowpanel_579",
+            "displayName": "Elecrow CrowPanel ESP32-S3 5.79in E-Paper HMI (SSD1683 x2)",
+            "binaryDir": "build/elecrow_crowpanel_579",
+            "cacheVariables": {
+                "SDKCONFIG_DEFAULTS": "sdkconfig.defaults;sdkconfig.defaults.elecrow_crowpanel_579",
+                "SDKCONFIG": "build/elecrow_crowpanel_579/sdkconfig"
+            }
         }
     ]
 }

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -225,7 +225,74 @@ FT6336U capacitive touch controller, so touch works alongside the BLE
 keyboard.
 
 
+## Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI Display
 
+[Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI
+Display](https://www.elecrow.com/crowpanel-esp32-5-79-e-paper-hmi-display-with-272-792-resolution-black-white-color-driven-by-spi-interface.html)
+-- ESP32-S3-WROOM-1-N8R8 driving a 792x272 black/white e-paper panel
+built from two SSD1683 controllers (one per half), over plain SPI.
+No touchscreen. On-board MicroSD on its own SPI bus. Five buttons:
+Menu, Back, a 3-way dial switch (Up/Down/OK), plus RESET and BOOT.
+
+The Menu button (GPIO2) is the deep-sleep wake source and, during
+normal operation, doubles as an F1 key (open/close the Settings
+menu) on a short press / "forget all BLE keyboards" on a 2 s hold --
+the same convention as the LilyGO T5 E-Paper S3 Pro H752's side key.
+The Back button and the dial switch round out full menu navigation
+without a keyboard: Back injects Esc, the dial's Up/Down positions
+inject the arrow keys, and pressing the dial (OK) injects Enter. No
+on-board battery ADC or fuel gauge was found in the vendor's Eagle
+schematic or Arduino examples (the "BAT" net is a bare JST connector
+with no divider wired to any GPIO), so the battery indicator is not
+available on this board.
+
+Pin assignments come from the vendor's [Arduino
+examples](https://github.com/Elecrow-RD/CrowPanel-ESP32-5.79-E-paper-HMI-Display-with-272-792)
+and Eagle schematic, cross-checked against the community ESPHome
+driver at
+[github.com/samperk1/esphome-crowpanel-579](https://github.com/samperk1/esphome-crowpanel-579),
+which reverse-engineered and photograph-verified the dual-SSD1683
+command sequences this backend ports
+(`components/display/display_ssd1683.cpp`).
+
+### E-paper refresh reliability
+
+The board has been extensively tested on real hardware (see [PR
+#47](https://github.com/clackups/draftling/pull/47)). Boot, buttons,
+dial, SD card, BLE keyboard input, deep sleep, and both partial and
+full e-paper refresh all work correctly.
+
+**Root cause.** A single Master Activation (`0x20`) trigger on this
+panel can leave an incomplete pixel transition -- confirmed, by
+systematically ruling out every other explanation on real hardware, to
+be independent of which waveform is used, of RAM content, and of
+typing speed. Immediately repeating the *exact same* update (a full
+RAM rewrite followed by another trigger, not just a bare re-trigger on
+unchanged RAM -- that was separately confirmed to actively erase the
+just-drawn content instead of fixing it) reliably completes the
+transition, matching what manually pressing Ctrl+R always did.
+`display_flush()` in `display_ssd1683.cpp` runs both the full and
+partial refresh paths twice, back-to-back, for this reason.
+
+Every refresh (partial or full) also rewrites the panel's *entire* New
+and Old RAM on both chips, not just the dirty rectangle -- an earlier,
+narrower-windowed implementation left the untouched rest of the panel
+implicitly relying on stale earlier writes, which testing found
+unreliable independent of the double-trigger issue above.
+
+**What was ruled out**, each independently confirmed on hardware,
+before the actual cause was found: a union dirty-bbox spanning most of
+the panel height; missing dual-chip cascade configuration (SSD1683
+datasheet section 6.12, register 0x21 "Display Update Control 1");
+Old RAM not resynced after a partial refresh; insufficient
+post-refresh settle time (tested from 100ms up to 2500ms); the
+waveform/LUT itself (tested the factory fast waveform, a from-scratch
+custom LUT built from the datasheet's own waveform-setting tables, and
+a hardware-verified custom LUT for a different SSD1683 panel -- all
+three showed the identical symptom, ruling out the waveform entirely);
+and a bare second trigger without rewriting RAM (actively harmful --
+erases just-drawn content rather than fixing it, which is what pointed
+toward "repeat the *whole* update" instead).
 
 
 

--- a/components/display/CMakeLists.txt
+++ b/components/display/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "display_rlcd.cpp" "display_epdiy.cpp" "display_h752.cpp" "epd_board_papers3.c" "display_axs15231b.cpp" "display_mipi_dsi.cpp" "display_rgb.cpp" "display_ili9341.cpp" "lvgl_port.cpp"
+    SRCS "display_rlcd.cpp" "display_epdiy.cpp" "display_h752.cpp" "epd_board_papers3.c" "display_axs15231b.cpp" "display_mipi_dsi.cpp" "display_rgb.cpp" "display_ili9341.cpp" "display_ssd1683.cpp" "lvgl_port.cpp"
     INCLUDE_DIRS "include"
     ## ESP-IDF 6.0 removed the legacy `driver` component's public
     ## dependencies on the split `esp_driver_*` components (see the

--- a/components/display/display_ssd1683.cpp
+++ b/components/display/display_ssd1683.cpp
@@ -103,8 +103,8 @@ static const char *TAG = "DisplaySSD1683";
  * the surrounding command sequence proceeds as if nothing went wrong.
  * This backend never needed to care while every send_buffer() call
  * was a small, narrow-window write; now that every refresh sends the
- * full HALF_BUF_LEN (13600 bytes, ~54 ms of clocking at this panel's
- * 2 MHz), the same failure mode applies here too. */
+ * full HALF_BUF_LEN (13600 bytes) to each chip, the same failure mode
+ * applies here too. */
 #define DMA_ALIGN_BYTES 64
 #define HALF_BUF_ALLOC_LEN (((size_t)HALF_BUF_LEN + DMA_ALIGN_BYTES - 1) & \
                             ~(size_t)(DMA_ALIGN_BYTES - 1))
@@ -619,7 +619,15 @@ extern "C" void display_init(int /*mosi*/, int /*sck*/, int /*dc*/,
     esp_lcd_panel_io_spi_config_t io_cfg = {};
     io_cfg.dc_gpio_num       = (gpio_num_t)EPD_DC_PIN;
     io_cfg.cs_gpio_num       = (gpio_num_t)EPD_CS_PIN;
-    io_cfg.pclk_hz           = 2 * 1000 * 1000;
+    /* SSD1683 datasheet Rev 1.0: "maximum SPI write speed 20MHz"
+     * (section 6.2) and fSCL write-mode max 20MHz (section 8, AC
+     * characteristics). Every refresh now clocks a full HALF_BUF_LEN
+     * (13600 bytes) to each chip twice per keystroke (see
+     * display_flush()), so this dominates per-keystroke latency --
+     * was 2MHz (no documented reason found for that choice), 10x
+     * below the chip's rated maximum. If this causes visible glitches
+     * (more likely with longer/marginal wiring), drop back down. */
+    io_cfg.pclk_hz           = 20 * 1000 * 1000;
     io_cfg.lcd_cmd_bits      = 8;
     io_cfg.lcd_param_bits    = 8;
     io_cfg.spi_mode          = 0;

--- a/components/display/display_ssd1683.cpp
+++ b/components/display/display_ssd1683.cpp
@@ -1,0 +1,828 @@
+#include "sdkconfig.h"
+#if defined(CONFIG_DRAFTLING_DISPLAY_SSD1683)
+
+/*
+ * Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI Display driver.
+ *
+ * Hardware
+ * --------
+ * 792x272 black/white e-paper panel built from two SSD1683 driver
+ * chips wired to the same SPI bus (shared CS/DC/RST/BUSY): one chip
+ * ("slave") drives the physical left half (columns 0-399), the other
+ * ("master") drives the right half (columns 392-791), with an
+ * 8-pixel overlap at the seam for alignment. The two chips are
+ * differentiated purely by their command set -- slave commands are
+ * 0x9x/0xCx/0xAx, master commands are the SSD1683's normal 0x1x/0x2x/
+ * 0x4x set -- so a single physical SPI transaction stream addresses
+ * whichever chip the active command belongs to.
+ *
+ * All panel pins (SCK=12, MOSI=11, DC=46, CS=45, RST=47, BUSY=48) and
+ * the panel power-enable pin (GPIO7, "IO7_LCD_3.3_CTL" on the vendor
+ * schematic, must be driven HIGH before the panel responds) are
+ * hard-coded below rather than carried in the board header: this
+ * backend is used by exactly one board, matching the convention
+ * already used by display_ili9341.cpp / display_xteink_epd.cpp.
+ *
+ * The master/slave RAM-window addressing math (including the master's
+ * inverted X-address counting and the seam-alignment special case in
+ * the partial-refresh byte range) originates from the community
+ * ESPHome driver at github.com/samperk1/esphome-crowpanel-579, which
+ * reverse-engineered and photograph-verified it against real CrowPanel
+ * 5.79" hardware. This backend has since been extensively verified on
+ * its own physical hardware too -- see HARDWARE.md and PR #47
+ * (github.com/clackups/draftling/pull/47) for that investigation.
+ *
+ * Framebuffer layout
+ * -------------------
+ * s_disp_buf is a plain 1-bpp buffer, 99 bytes/row (792/8) x 272
+ * rows, MSB-first, bit=1 -> white paper, bit=0 -> black ink (same
+ * polarity convention as display_rlcd.cpp). Byte 49 of every row
+ * (columns 392-399) is the seam: it is sent to *both* chips, which
+ * is how the panel firmware aligns the two halves.
+ *
+ * Refresh policy
+ * --------------
+ * Every refresh (partial or full) rewrites the *entire* panel's New
+ * and Old RAM on both chips, not just the dirty rectangle -- narrower
+ * windowing left the untouched rest of the panel's RAM implicitly
+ * relying on stale earlier writes, which on-hardware testing found
+ * unreliable (see epd_update_partial()'s own comment). display_flush()
+ * uses the fast OTP black/white LUT (waveform 0xFF) for ordinary
+ * edits, promoting to the full OTP waveform (0xF7) every
+ * CONFIG_DRAFTLING_EPD_FULL_REFRESH_INTERVAL refreshes or on request
+ * (display_clear/display_full_refresh/display_request_full_refresh).
+ * Both paths run their update twice, back-to-back: a single Master
+ * Activation trigger on this panel can leave an incomplete pixel
+ * transition regardless of waveform or RAM content, and immediately
+ * repeating the same update reliably completes it (see the
+ * CROWPANEL_PARTIAL_REFRESH comment near display_flush() for the full
+ * story).
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <esp_log.h>
+#include <esp_heap_caps.h>
+#include <driver/gpio.h>
+#include <driver/spi_master.h>
+#include <esp_lcd_panel_io.h>
+
+#include "display.h"
+
+static const char *TAG = "DisplaySSD1683";
+
+/* ---- Panel pins (this backend serves exactly one board) ---- */
+#define EPD_SCK_PIN     12
+#define EPD_MOSI_PIN    11
+#define EPD_DC_PIN      46
+#define EPD_CS_PIN      45
+#define EPD_RST_PIN     47
+#define EPD_BUSY_PIN    48
+#define EPD_PWR_PIN     7   /* IO7_LCD_3.3_CTL, active HIGH */
+
+#define EPD_SPI_HOST    SPI2_HOST
+
+/* ---- Panel geometry ---- */
+#define PANEL_W             792
+#define PANEL_H             272
+#define BYTES_PER_ROW       99   /* 792 / 8 */
+#define BYTES_PER_HALF_ROW  50   /* slave: bytes 0-49, master: bytes 49-98 */
+#define HALF_BUF_LEN        (BYTES_PER_HALF_ROW * PANEL_H)  /* 13600 */
+#define FULL_BUF_LEN         (BYTES_PER_ROW * PANEL_H)        /* 26928 */
+
+/* esp_lcd_panel_io_tx_color() bounces a PSRAM source buffer through a
+ * freshly malloc'd internal-DRAM copy unless io_cfg.flags.
+ * psram_dma_direct is set *and* the buffer is DMA-alignment-friendly
+ * -- see display_ili9341.cpp's DMA_ALIGN_BYTES comment for the full
+ * story (a documented, previously-fixed bug in this exact codebase):
+ * without it, that bounce allocation can silently fail under internal
+ * SRAM pressure, and esp_lcd_panel_io_tx_color()'s return value going
+ * unchecked means the rest of the buffer just never gets sent while
+ * the surrounding command sequence proceeds as if nothing went wrong.
+ * This backend never needed to care while every send_buffer() call
+ * was a small, narrow-window write; now that every refresh sends the
+ * full HALF_BUF_LEN (13600 bytes, ~54 ms of clocking at this panel's
+ * 2 MHz), the same failure mode applies here too. */
+#define DMA_ALIGN_BYTES 64
+#define HALF_BUF_ALLOC_LEN (((size_t)HALF_BUF_LEN + DMA_ALIGN_BYTES - 1) & \
+                            ~(size_t)(DMA_ALIGN_BYTES - 1))
+
+#ifdef CONFIG_DRAFTLING_EPD_FULL_REFRESH_INTERVAL
+#define SSD1683_FULL_REFRESH_INTERVAL CONFIG_DRAFTLING_EPD_FULL_REFRESH_INTERVAL
+#else
+#define SSD1683_FULL_REFRESH_INTERVAL 30
+#endif
+
+static esp_lcd_panel_io_handle_t s_io_handle = NULL;
+static uint8_t *s_disp_buf   = NULL;  /* FULL_BUF_LEN, PSRAM */
+static uint8_t *s_pack_a     = NULL;  /* HALF_BUF_LEN scratch, PSRAM */
+static uint8_t *s_pack_b     = NULL;  /* HALF_BUF_LEN scratch, PSRAM */
+static bool     s_initialized = false;
+
+/*
+ * Dirty rectangles accumulated since the last display_flush(). LVGL's
+ * PARTIAL render mode typically produces a couple of disjoint dirty
+ * areas per keystroke on the editor screen (the title bar's line/col
+ * indicator at the top of the panel, and the edited text line further
+ * down) -- see flush_cb() in lvgl_port.cpp. Collapsing those into a
+ * single unioned bounding box (the original approach here) meant every
+ * keystroke's partial refresh window spanned the vertical gap between
+ * them too, which on this panel's 272 px height can be most of the
+ * screen. The upstream community driver this backend is ported from
+ * (github.com/samperk1/esphome-crowpanel-579) never exercises a partial
+ * window anywhere near that large in its own photograph-verified test
+ * suite (partial_refresh_test.yaml only tries 200x112 / 391x60 windows)
+ * -- there is no evidence the panel's fast waveform is meant to run
+ * across that much untouched background, and doing so is a strong
+ * candidate for the "whole screen outside the edited line inverts
+ * black then white on every keystroke" symptom reported on real
+ * hardware. Tracking a handful of separate rectangles and refreshing
+ * each individually keeps every partial window tight to what actually
+ * changed, at the cost of one extra fixed-duration refresh event per
+ * extra disjoint area touched in a render cycle (the SSD1683's
+ * waveform runs for the same duration regardless of window size, so N
+ * separate windows costs roughly N times the single-window latency).
+ */
+#define MAX_DIRTY_RECTS 4
+
+struct DirtyRect {
+    int  x0, y0, x1, y1;
+    bool valid;
+};
+
+static DirtyRect s_dirty[MAX_DIRTY_RECTS];
+static bool s_force_full    = true;
+static int  s_partial_count = 0;
+
+/* Two rectangles are considered part of the same on-screen edit if
+ * they overlap or are within 1 px of touching -- pixels belonging to
+ * one LVGL invalidated area arrive from flush_cb() spatially
+ * contiguous (row by row within that area's bounds), so this reliably
+ * keeps one area's pixels in one slot while still starting a new slot
+ * for a spatially distant area. */
+static inline bool rects_mergeable(int ax0, int ay0, int ax1, int ay1,
+                                   int bx0, int by0, int bx1, int by1)
+{
+    return !(ax1 + 1 < bx0 || bx1 + 1 < ax0 ||
+              ay1 + 1 < by0 || by1 + 1 < ay0);
+}
+
+static inline void mark_dirty_rect(int x, int y, int w, int h)
+{
+    if (w <= 0 || h <= 0) return;
+    int x0 = x, y0 = y, x1 = x + w - 1, y1 = y + h - 1;
+    if (x0 < 0) x0 = 0;
+    if (y0 < 0) y0 = 0;
+    if (x1 >= PANEL_W) x1 = PANEL_W - 1;
+    if (y1 >= PANEL_H) y1 = PANEL_H - 1;
+    if (x1 < x0 || y1 < y0) return;
+
+    for (int i = 0; i < MAX_DIRTY_RECTS; i++) {
+        if (!s_dirty[i].valid) continue;
+        if (rects_mergeable(x0, y0, x1, y1, s_dirty[i].x0, s_dirty[i].y0,
+                            s_dirty[i].x1, s_dirty[i].y1)) {
+            if (x0 < s_dirty[i].x0) s_dirty[i].x0 = x0;
+            if (y0 < s_dirty[i].y0) s_dirty[i].y0 = y0;
+            if (x1 > s_dirty[i].x1) s_dirty[i].x1 = x1;
+            if (y1 > s_dirty[i].y1) s_dirty[i].y1 = y1;
+            return;
+        }
+    }
+    for (int i = 0; i < MAX_DIRTY_RECTS; i++) {
+        if (!s_dirty[i].valid) {
+            s_dirty[i].x0 = x0; s_dirty[i].y0 = y0;
+            s_dirty[i].x1 = x1; s_dirty[i].y1 = y1;
+            s_dirty[i].valid = true;
+            return;
+        }
+    }
+    /* All slots taken by mutually-distant rects: fall back to
+     * widening slot 0 rather than dropping the update. Still correct
+     * (s_disp_buf already has the right pixels either way), just less
+     * tightly windowed for this one edge case. */
+    if (x0 < s_dirty[0].x0) s_dirty[0].x0 = x0;
+    if (y0 < s_dirty[0].y0) s_dirty[0].y0 = y0;
+    if (x1 > s_dirty[0].x1) s_dirty[0].x1 = x1;
+    if (y1 > s_dirty[0].y1) s_dirty[0].y1 = y1;
+}
+
+static inline void clear_dirty(void)
+{
+    for (int i = 0; i < MAX_DIRTY_RECTS; i++) s_dirty[i].valid = false;
+}
+
+static inline bool any_dirty(void)
+{
+    for (int i = 0; i < MAX_DIRTY_RECTS; i++) if (s_dirty[i].valid) return true;
+    return false;
+}
+
+static void send_command(uint8_t cmd)
+{
+    esp_lcd_panel_io_tx_param(s_io_handle, cmd, NULL, 0);
+}
+
+static void send_data(uint8_t data)
+{
+    esp_lcd_panel_io_tx_param(s_io_handle, -1, &data, 1);
+}
+
+static void send_buffer(const uint8_t *data, size_t len)
+{
+    esp_lcd_panel_io_tx_color(s_io_handle, -1, data, len);
+}
+
+static void send_ram(uint8_t cmd, const uint8_t *data, size_t len)
+{
+    send_command(cmd);
+    send_buffer(data, len);
+}
+
+static void hw_reset(void)
+{
+    gpio_set_level((gpio_num_t)EPD_RST_PIN, 1);
+    vTaskDelay(pdMS_TO_TICKS(10));
+    gpio_set_level((gpio_num_t)EPD_RST_PIN, 0);
+    vTaskDelay(pdMS_TO_TICKS(10));
+    gpio_set_level((gpio_num_t)EPD_RST_PIN, 1);
+    vTaskDelay(pdMS_TO_TICKS(10));
+}
+
+static void wait_busy(void)
+{
+    /* BUSY is active HIGH on the SSD1683. Poll at 10 ms with a 10 s
+     * ceiling (a full refresh takes ~2-3 s; 10 s leaves generous
+     * headroom without hanging forever on a wiring fault). */
+    for (int i = 0; i < 1000; i++) {
+        if (gpio_get_level((gpio_num_t)EPD_BUSY_PIN) == 0) return;
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    ESP_LOGE(TAG, "BUSY timeout");
+}
+
+/* Extra settle time after a "Master Activation" (0x20) refresh
+ * completes (BUSY low), before this backend will issue the next
+ * command sequence. Editing text triggers a display refresh on
+ * essentially every keystroke, so refreshes on this panel are
+ * routinely issued back-to-back the moment BUSY clears -- far more
+ * rapidly than the single, human-paced button presses the upstream
+ * ESPHome driver this backend is ported from was exercised with.
+ * Field testing on real hardware showed the whole panel alternating
+ * between an old, fully-settled frame and the current one on every
+ * keystroke under that rapid-fire pattern; the SSD1683 datasheet's
+ * own documented Wait-BUSY-Low synchronization point may not fully
+ * cover the panel's analog rail settle time once a *new* refresh
+ * starts immediately after -- BUSY going low ends the chip's own
+ * internal processing, but the panel's pixels may still be
+ * physically mid-transition, and starting the next refresh's RAM
+ * write + trigger right then would cut that transition short,
+ * leaving pixels part-way reverted toward what they looked like
+ * before this refresh started. This mirrors the debounce/settle
+ * handling display_epdiy.cpp already needs for the same "rapid
+ * typing hammers an e-paper backend" scenario. Applied only after
+ * an actual "Master Activation" refresh (not the shorter waits used
+ * during LUT loading in init_display()). 100ms was not enough to
+ * eliminate an earlier, different-looking symptom (the whole panel
+ * alternating between two full frames); bumped to 400ms. A separate,
+ * more serious "recently-written text goes missing" symptom traced
+ * to a much longer settle time (2500ms) made no difference either --
+ * see the CROWPANEL_PARTIAL_REFRESH comment near display_flush() for
+ * what actually fixed that one. */
+#define EPD_REFRESH_SETTLE_MS 400
+
+static void wait_busy_after_refresh(void)
+{
+    wait_busy();
+    vTaskDelay(pdMS_TO_TICKS(EPD_REFRESH_SETTLE_MS));
+}
+
+/*
+ * Point one chip's RAM window at [bs, be] (inclusive column-byte
+ * indices, chip-local) x [y0, y1] (inclusive panel rows) and leave
+ * the address counter at the start of that window. Called both for
+ * the full-panel window (init / full refresh) and for a clipped
+ * sub-window (partial refresh) -- the two are the same operation at
+ * different extents.
+ *
+ * The master's X addressing counts down from the high byte (entry
+ * mode 0x02: Y increment, X decrement), so its byte range [bs, be]
+ * (bs = left/low column, be = right/high column, both in the shared
+ * 0-98 buffer-byte index space) maps to chip-local X addresses
+ * [98-bs, 98-be] -- see the "Master: X addressing" note in the
+ * upstream ESPHome driver this is ported from.
+ */
+static void set_window_slave(int bs, int be, int y0, int y1)
+{
+    send_command(0x91); send_data(0x03);
+    send_command(0xC4); send_data((uint8_t)(bs & 0x3F)); send_data((uint8_t)(be & 0x3F));
+    send_command(0xC5); send_data((uint8_t)(y0 & 0xFF)); send_data((uint8_t)((y0 >> 8) & 0x01));
+                        send_data((uint8_t)(y1 & 0xFF)); send_data((uint8_t)((y1 >> 8) & 0x01));
+    send_command(0xCE); send_data((uint8_t)(bs & 0x3F));
+    send_command(0xCF); send_data((uint8_t)(y0 & 0xFF)); send_data((uint8_t)((y0 >> 8) & 0x01));
+}
+
+static void set_window_master(int bs, int be, int y0, int y1)
+{
+    int xs = 98 - bs;
+    int xe = 98 - be;
+    send_command(0x11); send_data(0x02);
+    send_command(0x44); send_data((uint8_t)(xs & 0x3F)); send_data((uint8_t)(xe & 0x3F));
+    send_command(0x45); send_data((uint8_t)(y0 & 0xFF)); send_data((uint8_t)((y0 >> 8) & 0x01));
+                        send_data((uint8_t)(y1 & 0xFF)); send_data((uint8_t)((y1 >> 8) & 0x01));
+    send_command(0x4E); send_data((uint8_t)(xs & 0x3F));
+    send_command(0x4F); send_data((uint8_t)(y0 & 0xFF)); send_data((uint8_t)((y0 >> 8) & 0x01));
+}
+
+/* Pack the [bs, be] x [y0, y1] sub-rectangle of s_disp_buf (row
+ * stride BYTES_PER_ROW) into a contiguous scratch buffer, ready for
+ * one send_buffer() burst. */
+static void pack_window(uint8_t *dst, int bs, int be, int y0, int y1)
+{
+    int w = be - bs + 1;
+    for (int y = y0; y <= y1; y++) {
+        memcpy(dst + (size_t)(y - y0) * (size_t)w,
+               s_disp_buf + (size_t)y * BYTES_PER_ROW + bs, (size_t)w);
+    }
+}
+
+/*
+ * Configure both chips for "Cascade application" (SSD1683 datasheet
+ * "Display Update Control 1", command 0x21, second data byte bit 4)
+ * before every Master Activation. Datasheet section 6.12 documents
+ * this as required for exactly this board's wiring -- two SSD1683
+ * chips sharing one CL synchronization pin, one "master" and one
+ * "slave" -- but this backend never sent it at all until now. An
+ * earlier attempt at adding it (git log ca0df1d, reverted after a
+ * severe hardware regression: "nothing renders, screen fades to
+ * white") sent 0x21 only to the master's command range and never to
+ * the slave's remapped range. Every other command this driver sends
+ * to the slave chip is the master's command plus 0x80 (0x11->0x91,
+ * 0x44->0xC4, 0x24->0xA4, 0x26->0xA6 -- see set_window_slave() above,
+ * verified against samperk1's hardware-tested driver), so 0x21's
+ * slave equivalent is 0xA1. Leaving the master in cascade mode while
+ * the slave stayed at its power-on-reset default of "single chip
+ * application" is a far more likely explanation for that regression
+ * (the two chips' activation state machines disagreeing about how to
+ * hand off to each other) than the cascade command itself being
+ * wrong -- especially since that failure was identical across four
+ * separate follow-up attempts that each isolated a different other
+ * variable and left this one unchanged. This sends it to both chips.
+ */
+static void set_cascade_mode(void)
+{
+    send_command(0x21); send_data(0x00); send_data(0x10);
+    send_command(0xA1); send_data(0x00); send_data(0x10);
+}
+
+/*
+ * GxEPD2's reference driver for this exact panel
+ * (github.com/ZinggJM/GxEPD2, src/gdey/GxEPD2_579_GDEY0579T93.cpp --
+ * a far more widely used and hardware-tested library than the
+ * single-author ESPHome driver this backend was originally ported
+ * from) re-addresses *both* chips to their full local RAM range
+ * immediately before every Master Activation trigger, full or
+ * partial, regardless of how narrow the preceding data write's own
+ * window was (see its refresh(int16_t,int16_t,int16_t,int16_t) and
+ * refresh(bool)). This backend never did that -- it fires the
+ * trigger using whatever window the preceding data write left
+ * active. If the SSD1683's internal refresh/waveform engine needs
+ * the RAM address-range registers to cover the full panel at trigger
+ * time to behave correctly, regardless of how little data was
+ * actually written, triggering with a narrow window still active (as
+ * this backend always has) could plausibly leave the untouched
+ * remainder of the panel in an undefined state -- a candidate
+ * explanation for the "shows a stale prior frame" symptom that five
+ * other independent Old/New-RAM-focused fix attempts did not
+ * resolve. This exact change was tried once before (git log
+ * ca0df1d), but bundled together with the master-only cascade-mode
+ * bug that same commit introduced, and reverted along with it before
+ * ever being isolated and re-tested against the since-fixed cascade
+ * configuration.
+ *
+ * The master's re-address here uses entry mode 0x03 (X increment),
+ * not the 0x02 (X decrement + inversion) set_window_master() uses
+ * for actual data writes -- matching GxEPD2's
+ * _setPartialRamAreaMaster() default mode exactly. This call carries
+ * no data of its own (see its call sites), so the direction bit does
+ * not affect what ends up in RAM; using GxEPD2's exact mode keeps
+ * this faithful to a hardware-verified reference rather than
+ * reusing our own data-write-specific convention for a different
+ * purpose.
+ */
+static void set_full_window_for_trigger(void)
+{
+    set_window_slave(0, 49, 0, PANEL_H - 1);
+
+    send_command(0x11); send_data(0x03);
+    send_command(0x44); send_data(0x00); send_data(0x31);
+    send_command(0x45); send_data(0x00); send_data(0x00);
+                        send_data((uint8_t)((PANEL_H - 1) & 0xFF));
+                        send_data((uint8_t)(((PANEL_H - 1) >> 8) & 0x01));
+    send_command(0x4E); send_data(0x00);
+    send_command(0x4F); send_data(0x00); send_data(0x00);
+}
+
+static void epd_update_full(void)
+{
+    set_window_slave(0, 49, 0, PANEL_H - 1);
+    pack_window(s_pack_a, 0, 49, 0, PANEL_H - 1);
+    send_ram(0xA4, s_pack_a, HALF_BUF_LEN);
+
+    set_window_master(49, 98, 0, PANEL_H - 1);
+    pack_window(s_pack_b, 49, 98, 0, PANEL_H - 1);
+    send_ram(0x24, s_pack_b, HALF_BUF_LEN);
+
+    set_full_window_for_trigger();
+    set_cascade_mode();
+    send_command(0x22); send_data(0xF7);  /* full OTP waveform */
+    send_command(0x20);
+    wait_busy_after_refresh();
+
+    /* Keep Old RAM in sync with what is now actually on the panel
+     * (s_pack_a/s_pack_b already hold exactly that content from the
+     * packing above -- nothing overwrote them across the trigger) so
+     * that any *partial* refresh which does not happen to touch a
+     * given chip still has an accurate Old-RAM baseline there. Both
+     * chips' Master Activation is a shared broadcast trigger (there
+     * is no way to fire only one), so a partial refresh whose dirty
+     * rect only touches one chip's columns still re-triggers the
+     * *other* chip's own refresh using whatever is currently in its
+     * RAM -- if that chip's Old RAM were left stale (mismatched
+     * against its own unchanged, correct New RAM), every such
+     * unrelated keystroke would still make it redraw as if content
+     * had changed there. This was the previous approach here
+     * (forcing Old RAM to all-black after every full refresh), on the
+     * theory that the 0xF7 GC16 waveform's own documented auto-copy
+     * of New->Old after refresh needed correcting to avoid a stuck-
+     * black W->W transition on a later *repeat* full refresh -- but
+     * forcing it to black is exactly the mismatch described above,
+     * every single time until the next full refresh. A live editor's
+     * content is essentially never byte-identical across two full
+     * refreshes 30 keystrokes apart, so the repeat-content stuck-
+     * black risk this used to guard against is far less costly than
+     * paying it on every partial refresh in between. */
+    set_window_slave(0, 49, 0, PANEL_H - 1);
+    send_ram(0xA6, s_pack_a, HALF_BUF_LEN);
+
+    set_window_master(49, 98, 0, PANEL_H - 1);
+    send_ram(0x26, s_pack_b, HALF_BUF_LEN);
+}
+
+/*
+ * Rewrite the *entire* panel's New and Old RAM, on both chips, before
+ * every partial refresh -- not just the dirty rectangle. Narrower
+ * windowing (this function's previous approach, and GxEPD2's own
+ * writeImage()/writeImageAgain(), which only touch the dirty area)
+ * still left every partial refresh's trigger implicitly relying on
+ * whatever the *rest* of the panel's RAM already held from earlier
+ * writes. On-hardware testing kept finding cases where that RAM
+ * didn't actually hold what software believed it did, however
+ * carefully each individual write and sync was ordered. Writing the
+ * complete, authoritative s_disp_buf content to New RAM (so New RAM
+ * can never be anything other than exactly correct) and then to Old
+ * RAM (so Old RAM always reflects exactly what New RAM held one
+ * refresh ago, for every pixel, not just the ones a given keystroke
+ * happened to touch) removes any way for a region's RAM to drift out
+ * of sync with reality between refreshes, at the cost of the same
+ * SPI transfer size as a full refresh -- only the waveform selector
+ * (0xFF fast vs 0xF7 full, still on the dirty-triggered vs periodic
+ * cadence display_flush() already applies) still distinguishes a
+ * "partial" refresh from a full one. */
+static void epd_update_partial(void)
+{
+    set_window_slave(0, 49, 0, PANEL_H - 1);
+    pack_window(s_pack_a, 0, 49, 0, PANEL_H - 1);
+    send_ram(0xA4, s_pack_a, HALF_BUF_LEN);
+
+    set_window_master(49, 98, 0, PANEL_H - 1);
+    pack_window(s_pack_b, 49, 98, 0, PANEL_H - 1);
+    send_ram(0x24, s_pack_b, HALF_BUF_LEN);
+
+    /* Border waveform override (VCOM), re-asserted before every
+     * partial trigger -- matches GxEPD2's _Update_Part() exactly.
+     * init_display()'s own border-waveform command carries over for
+     * full refreshes (GxEPD2's _Update_Full() does not set this
+     * either). */
+    send_command(0x3C); send_data(0x80);
+
+    set_full_window_for_trigger();
+    set_cascade_mode();
+    send_command(0x22); send_data(0xFF);  /* fast B/W OTP LUT */
+    send_command(0x20);
+    wait_busy_after_refresh();
+
+    /* s_pack_a/s_pack_b still hold exactly what was just written as
+     * New RAM (nothing overwrote them across the trigger) -- reuse
+     * them to keep Old RAM in sync with the whole panel too. */
+    set_window_slave(0, 49, 0, PANEL_H - 1);
+    send_ram(0xA6, s_pack_a, HALF_BUF_LEN);
+
+    set_window_master(49, 98, 0, PANEL_H - 1);
+    send_ram(0x26, s_pack_b, HALF_BUF_LEN);
+}
+
+static void init_display(void)
+{
+    hw_reset();
+    wait_busy();
+
+    send_command(0x12);  /* SW reset */
+    wait_busy();
+
+    send_command(0x18); send_data(0x80);  /* internal temperature sensor */
+    send_command(0x22); send_data(0xB1);  /* enable clock, CP, load temp */
+    send_command(0x20);
+    wait_busy();
+
+    send_command(0x1A); send_data(0x64); send_data(0x00);  /* temperature value */
+
+    send_command(0x22); send_data(0x91);  /* enable clock, load LUT from OTP */
+    send_command(0x20);
+    wait_busy();
+
+    send_command(0x3C); send_data(0x03);  /* border waveform */
+    wait_busy();
+
+    /* Bring both chips' New and Old RAM to all-black, so the
+     * clean-to-white full refresh below fires a real B->W transition
+     * across the whole panel instead of relying on undefined POR
+     * RAM contents. */
+    set_window_master(49, 98, 0, PANEL_H - 1);
+    memset(s_pack_b, 0x00, HALF_BUF_LEN);
+    send_ram(0x24, s_pack_b, HALF_BUF_LEN);
+    set_window_master(49, 98, 0, PANEL_H - 1);
+    send_ram(0x26, s_pack_b, HALF_BUF_LEN);
+
+    set_window_slave(0, 49, 0, PANEL_H - 1);
+    memset(s_pack_a, 0x00, HALF_BUF_LEN);
+    send_ram(0xA4, s_pack_a, HALF_BUF_LEN);
+    set_window_slave(0, 49, 0, PANEL_H - 1);
+    send_ram(0xA6, s_pack_a, HALF_BUF_LEN);
+
+    set_cascade_mode();
+    send_command(0x22); send_data(0xF7);
+    send_command(0x20);
+    wait_busy();
+}
+
+/* ---- public API ---- */
+
+extern "C" void display_init(int /*mosi*/, int /*sck*/, int /*dc*/,
+                             int /*cs*/, int /*rst*/, int /*busy*/,
+                             int width, int height)
+{
+    if (s_initialized) return;
+
+    if (width != PANEL_W || height != PANEL_H) {
+        ESP_LOGW(TAG, "Configured %dx%d does not match panel size %dx%d; "
+                      "using panel size", width, height, PANEL_W, PANEL_H);
+    }
+
+    /* Panel power rail, driven once at boot and left alone --
+     * display_deep_sleep_prepare() does not touch it (see that
+     * function). gpio_hold_dis() is a defensive no-op unless a pad
+     * hold survived from a firmware version that used to cut this
+     * pin before sleep. */
+    gpio_hold_dis((gpio_num_t)EPD_PWR_PIN);
+    gpio_config_t pwr_cfg = {};
+    pwr_cfg.intr_type    = GPIO_INTR_DISABLE;
+    pwr_cfg.mode         = GPIO_MODE_OUTPUT;
+    pwr_cfg.pin_bit_mask = (1ULL << EPD_PWR_PIN);
+    ESP_ERROR_CHECK(gpio_config(&pwr_cfg));
+    gpio_set_level((gpio_num_t)EPD_PWR_PIN, 1);
+    vTaskDelay(pdMS_TO_TICKS(10));
+
+    gpio_config_t rst_cfg = {};
+    rst_cfg.intr_type    = GPIO_INTR_DISABLE;
+    rst_cfg.mode         = GPIO_MODE_OUTPUT;
+    rst_cfg.pin_bit_mask = (1ULL << EPD_RST_PIN);
+    ESP_ERROR_CHECK(gpio_config(&rst_cfg));
+
+    gpio_config_t busy_cfg = {};
+    busy_cfg.intr_type    = GPIO_INTR_DISABLE;
+    busy_cfg.mode         = GPIO_MODE_INPUT;
+    busy_cfg.pin_bit_mask = (1ULL << EPD_BUSY_PIN);
+    busy_cfg.pull_down_en = GPIO_PULLDOWN_ENABLE;
+    ESP_ERROR_CHECK(gpio_config(&busy_cfg));
+
+    spi_bus_config_t bus_cfg = {};
+    bus_cfg.mosi_io_num     = EPD_MOSI_PIN;
+    bus_cfg.miso_io_num     = -1;
+    bus_cfg.sclk_io_num     = EPD_SCK_PIN;
+    bus_cfg.quadwp_io_num   = -1;
+    bus_cfg.quadhd_io_num   = -1;
+    bus_cfg.max_transfer_sz = HALF_BUF_LEN;
+    ESP_ERROR_CHECK(spi_bus_initialize(EPD_SPI_HOST, &bus_cfg, SPI_DMA_CH_AUTO));
+
+    esp_lcd_panel_io_spi_config_t io_cfg = {};
+    io_cfg.dc_gpio_num       = (gpio_num_t)EPD_DC_PIN;
+    io_cfg.cs_gpio_num       = (gpio_num_t)EPD_CS_PIN;
+    io_cfg.pclk_hz           = 2 * 1000 * 1000;
+    io_cfg.lcd_cmd_bits      = 8;
+    io_cfg.lcd_param_bits    = 8;
+    io_cfg.spi_mode          = 0;
+    io_cfg.trans_queue_depth = 10;
+    /* See the DMA_ALIGN_BYTES comment above -- without this flag, a
+     * PSRAM source buffer gets bounced through a freshly malloc'd
+     * internal-DRAM copy that can silently fail (and drop the rest of
+     * the transfer) once internal SRAM is under pressure. */
+    io_cfg.flags.psram_dma_direct = 1;
+    ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)EPD_SPI_HOST,
+                                             &io_cfg, &s_io_handle));
+
+    s_disp_buf = (uint8_t *)heap_caps_malloc(FULL_BUF_LEN, MALLOC_CAP_SPIRAM);
+    /* Aligned (and sized so the whole buffer stays aligned) so the
+     * psram_dma_direct fast path above is always taken instead of
+     * falling back to the internal-DRAM bounce copy. */
+    s_pack_a = (uint8_t *)heap_caps_aligned_alloc(DMA_ALIGN_BYTES, HALF_BUF_ALLOC_LEN,
+                                                  MALLOC_CAP_SPIRAM);
+    s_pack_b = (uint8_t *)heap_caps_aligned_alloc(DMA_ALIGN_BYTES, HALF_BUF_ALLOC_LEN,
+                                                  MALLOC_CAP_SPIRAM);
+    assert(s_disp_buf && s_pack_a && s_pack_b);
+    memset(s_disp_buf, 0xFF, FULL_BUF_LEN);  /* 0xFF = white paper */
+
+    init_display();
+
+    clear_dirty();
+    s_force_full    = true;
+    s_partial_count = 0;
+    s_initialized   = true;
+
+    ESP_LOGI(TAG, "SSD1683 x2 %dx%d initialized, full refresh every %d partials",
+             PANEL_W, PANEL_H, SSD1683_FULL_REFRESH_INTERVAL);
+}
+
+extern "C" void display_clear(uint8_t color)
+{
+    if (!s_initialized) return;
+    memset(s_disp_buf, color, FULL_BUF_LEN);
+    mark_dirty_rect(0, 0, PANEL_W, PANEL_H);
+    s_force_full = true;
+}
+
+extern "C" void display_set_pixel(uint16_t x, uint16_t y, uint8_t color)
+{
+    if (!s_initialized) return;
+    if (x >= PANEL_W || y >= PANEL_H) return;
+    size_t idx  = (size_t)y * BYTES_PER_ROW + (x >> 3);
+    uint8_t mask = (uint8_t)(0x80 >> (x & 7));
+    if (color) s_disp_buf[idx] |= mask;   /* bit=1: white paper */
+    else       s_disp_buf[idx] &= (uint8_t)~mask;  /* bit=0: black ink */
+    mark_dirty_rect(x, y, 1, 1);
+}
+
+extern "C" bool display_push_rgb565(int /*x*/, int /*y*/, int /*w*/, int /*h*/,
+                                    const void * /*color_map*/)
+{
+    /* No fast path -- lvgl_port.cpp falls back to the per-pixel
+     * display_set_pixel conversion (same as display_rlcd.cpp). */
+    return false;
+}
+
+/*
+ * A single Master Activation trigger on this panel can leave an
+ * incomplete pixel transition -- independent of which waveform is
+ * used and regardless of RAM content, confirmed on real hardware (see
+ * PR #47 discussion, github.com/clackups/draftling/pull/47).
+ * Immediately repeating the exact same update a second time reliably
+ * completes it, matching what pressing Ctrl+R already did manually --
+ * display_flush() below runs both the full and partial refresh paths
+ * twice for this reason. Re-triggering *without* rewriting RAM does
+ * not work (it actively erases the just-drawn content instead); the
+ * second call must be a full, independent run of the update.
+ */
+#define CROWPANEL_PARTIAL_REFRESH 1
+
+extern "C" void display_flush(void)
+{
+    if (!s_initialized) return;
+    if (!any_dirty()) return;
+
+#if CROWPANEL_PARTIAL_REFRESH
+    /* Unlike display_epdiy.cpp (whose "huge dirty area -> promote to
+     * full" rule exists to dodge a specific async-feeder-task wedge
+     * bug in that backend's LCD-peripheral render path), this backend
+     * is a plain synchronous SPI driver with no equivalent failure
+     * mode, so that promotion isn't ported here: with the editor's
+     * title bar sitting at the top of a 272 px panel -- the shortest
+     * of any supported board, by a wide margin -- a *single* dirty
+     * rectangle this large would cover a much larger fraction of this
+     * panel's height than the same absolute pixel span would on any
+     * taller board. The upstream community driver this backend is
+     * ported from exercises partial refreshes at least this large
+     * (e.g. a 200x112 px window) successfully, so there is no
+     * evidence the panel itself needs a single rectangle's area
+     * capped -- see mark_dirty_rect()'s block comment for why the
+     * title bar and the edited line are kept as separate rectangles
+     * instead of one that also spans the untouched gap between them.
+     * Only an explicit request (display_clear/display_full_refresh/
+     * display_request_full_refresh) or the periodic
+     * CONFIG_DRAFTLING_EPD_FULL_REFRESH_INTERVAL ghost-clearing pass
+     * promotes to full here. */
+    bool do_full = s_force_full ||
+                   s_partial_count >= SSD1683_FULL_REFRESH_INTERVAL;
+#else
+    bool do_full = true;
+#endif
+
+    if (do_full) {
+        /* Called twice -- see the CROWPANEL_PARTIAL_REFRESH comment
+         * above. */
+        epd_update_full();
+        epd_update_full();
+        s_partial_count = 0;
+        s_force_full    = false;
+    } else {
+        /* epd_update_partial() rewrites the entire panel's RAM on
+         * every call (see its own comment), so calling it once per
+         * s_dirty[] entry here (left over from when it only wrote a
+         * narrow window) would repeat the same ~1s+ full-buffer
+         * transfer up to MAX_DIRTY_RECTS times for a single keystroke,
+         * for no benefit -- call it twice total instead, matching
+         * epd_update_full()'s fix above. */
+        epd_update_partial();
+        epd_update_partial();
+        s_partial_count++;
+    }
+
+    clear_dirty();
+}
+
+extern "C" void display_full_refresh(void)
+{
+    if (!s_initialized) return;
+    mark_dirty_rect(0, 0, PANEL_W, PANEL_H);
+    s_force_full = true;
+    display_flush();
+}
+
+extern "C" void display_request_full_refresh(void)
+{
+    if (!s_initialized) return;
+    s_force_full = true;
+}
+
+extern "C" void display_set_partial_clip(int /*x*/, int /*y*/,
+                                         int /*w*/, int /*h*/)
+{
+    /* No-op on this backend; the dirty bbox already drives the
+     * refresh region. */
+}
+
+extern "C" uint8_t *display_get_buffer(void)
+{
+    return s_disp_buf;
+}
+
+extern "C" int display_get_buffer_size(void)
+{
+    return FULL_BUF_LEN;
+}
+
+extern "C" void display_set_backlight(int /*percent*/)
+{
+    /* No backlight on this panel. No-op. */
+}
+
+extern "C" void display_sleep(void)
+{
+    /* E-paper retains its image without power; the standby manager
+     * uses deep sleep on this board rather than
+     * CONFIG_DRAFTLING_STANDBY_DISPLAY_OFF. No-op, matching every
+     * other e-paper backend in this codebase. */
+}
+
+extern "C" void display_wake(void)
+{
+    /* No-op (see display_sleep). */
+}
+
+extern "C" void display_deep_sleep_prepare(void)
+{
+    /* display.h's documented contract for this call is a no-op on
+     * e-paper backends ("the panel retains its image without
+     * power"), matching display_rlcd.cpp / display_epdiy.cpp.
+     *
+     * An earlier version of this backend cut the panel's 3.3 V rail
+     * (EPD_PWR_PIN) here, on the theory that the SSD1683 is bistable
+     * and a power cut right after a completed refresh is harmless.
+     * On real hardware this left the panel showing its pre-sleep
+     * content instead of the white frame pre_sleep_autosave() had
+     * just pushed and waited for BUSY to confirm -- cutting power
+     * without first issuing the controller's own deep-sleep command
+     * (0x10, unverified opcode for the slave half of this dual-chip
+     * panel) evidently does not commit the last waveform cleanly on
+     * this panel. Leaving the rail powered avoids that regression;
+     * the panel's own standby current when idle is low enough that
+     * this is not worth the risk without a verified safe power-down
+     * sequence. */
+}
+
+extern "C" void display_set_shared_i2c_bus(void * /*bus_handle*/)
+{
+    /* This backend does not use I2C. No-op. */
+}
+
+#endif /* CONFIG_DRAFTLING_DISPLAY_SSD1683 */

--- a/components/display/display_ssd1683.cpp
+++ b/components/display/display_ssd1683.cpp
@@ -92,19 +92,16 @@ static const char *TAG = "DisplaySSD1683";
 #define HALF_BUF_LEN        (BYTES_PER_HALF_ROW * PANEL_H)  /* 13600 */
 #define FULL_BUF_LEN         (BYTES_PER_ROW * PANEL_H)        /* 26928 */
 
-/* esp_lcd_panel_io_tx_color() bounces a PSRAM source buffer through a
- * freshly malloc'd internal-DRAM copy unless io_cfg.flags.
- * psram_dma_direct is set *and* the buffer is DMA-alignment-friendly
- * -- see display_ili9341.cpp's DMA_ALIGN_BYTES comment for the full
- * story (a documented, previously-fixed bug in this exact codebase):
- * without it, that bounce allocation can silently fail under internal
- * SRAM pressure, and esp_lcd_panel_io_tx_color()'s return value going
- * unchecked means the rest of the buffer just never gets sent while
- * the surrounding command sequence proceeds as if nothing went wrong.
- * This backend never needed to care while every send_buffer() call
- * was a small, narrow-window write; now that every refresh sends the
- * full HALF_BUF_LEN (13600 bytes) to each chip, the same failure mode
- * applies here too. */
+/* Alignment for s_pack_a/s_pack_b (see display_init()), the only
+ * buffers ever handed to esp_lcd_panel_io_tx_color() (via
+ * send_buffer()). They live in internal, natively DMA-capable RAM
+ * (MALLOC_CAP_DMA), which does not need this backend to worry about
+ * the PSRAM-source bounce-buffer/cache-sync path that
+ * display_ili9341.cpp's own DMA_ALIGN_BYTES comment documents (a
+ * previously-fixed bug in this exact codebase, where a PSRAM source
+ * buffer silently bounced through a fallible internal-DRAM copy under
+ * memory pressure) -- kept here mainly as defensive, cheap alignment
+ * for the DMA engine in general. */
 #define DMA_ALIGN_BYTES 64
 #define HALF_BUF_ALLOC_LEN (((size_t)HALF_BUF_LEN + DMA_ALIGN_BYTES - 1) & \
                             ~(size_t)(DMA_ALIGN_BYTES - 1))
@@ -117,8 +114,8 @@ static const char *TAG = "DisplaySSD1683";
 
 static esp_lcd_panel_io_handle_t s_io_handle = NULL;
 static uint8_t *s_disp_buf   = NULL;  /* FULL_BUF_LEN, PSRAM */
-static uint8_t *s_pack_a     = NULL;  /* HALF_BUF_LEN scratch, PSRAM */
-static uint8_t *s_pack_b     = NULL;  /* HALF_BUF_LEN scratch, PSRAM */
+static uint8_t *s_pack_a     = NULL;  /* HALF_BUF_LEN scratch, internal DMA-capable RAM */
+static uint8_t *s_pack_b     = NULL;  /* HALF_BUF_LEN scratch, internal DMA-capable RAM */
 static bool     s_initialized = false;
 
 /*
@@ -632,22 +629,39 @@ extern "C" void display_init(int /*mosi*/, int /*sck*/, int /*dc*/,
     io_cfg.lcd_param_bits    = 8;
     io_cfg.spi_mode          = 0;
     io_cfg.trans_queue_depth = 10;
-    /* See the DMA_ALIGN_BYTES comment above -- without this flag, a
-     * PSRAM source buffer gets bounced through a freshly malloc'd
-     * internal-DRAM copy that can silently fail (and drop the rest of
-     * the transfer) once internal SRAM is under pressure. */
+    /* Currently a no-op in practice -- see the DMA_ALIGN_BYTES comment
+     * above, s_pack_a/s_pack_b (the only buffers ever DMA'd here) are
+     * internal RAM, not PSRAM, so this flag's PSRAM-specific fast path
+     * never triggers. Left set defensively/cheaply in case that ever
+     * changes back. */
     io_cfg.flags.psram_dma_direct = 1;
     ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)EPD_SPI_HOST,
                                              &io_cfg, &s_io_handle));
 
+    /* s_disp_buf is the authoritative framebuffer -- only ever read via
+     * memcpy() inside pack_window(), never itself handed to
+     * esp_lcd_panel_io_tx_color() -- so it has no DMA-capability
+     * requirement and stays in PSRAM (abundant, and at FULL_BUF_LEN
+     * the largest of these three buffers).
+     *
+     * s_pack_a/s_pack_b ARE the buffers handed to tx_color() for every
+     * refresh's actual SPI transfer, twice per keystroke (see
+     * display_flush()) -- putting these in internal, natively
+     * DMA-capable RAM instead skips the whole PSRAM-DMA path entirely
+     * (the psram_dma_direct flag and cache-sync/bounce-buffer concerns
+     * in the comments above only apply to external-RAM source
+     * buffers; MALLOC_CAP_DMA|MALLOC_CAP_INTERNAL memory was never
+     * that fragile fallback path to begin with). This costs ~27KB of
+     * this chip's much scarcer internal SRAM (vs. abundant 8MB PSRAM)
+     * -- if that turns out to starve the BLE/Wi-Fi stack under real
+     * use, move these back to MALLOC_CAP_SPIRAM (the assert() below
+     * will fail loudly at boot on outright allocation failure, not
+     * silently corrupt anything). */
     s_disp_buf = (uint8_t *)heap_caps_malloc(FULL_BUF_LEN, MALLOC_CAP_SPIRAM);
-    /* Aligned (and sized so the whole buffer stays aligned) so the
-     * psram_dma_direct fast path above is always taken instead of
-     * falling back to the internal-DRAM bounce copy. */
     s_pack_a = (uint8_t *)heap_caps_aligned_alloc(DMA_ALIGN_BYTES, HALF_BUF_ALLOC_LEN,
-                                                  MALLOC_CAP_SPIRAM);
+                                                  MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
     s_pack_b = (uint8_t *)heap_caps_aligned_alloc(DMA_ALIGN_BYTES, HALF_BUF_ALLOC_LEN,
-                                                  MALLOC_CAP_SPIRAM);
+                                                  MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
     assert(s_disp_buf && s_pack_a && s_pack_b);
     memset(s_disp_buf, 0xFF, FULL_BUF_LEN);  /* 0xFF = white paper */
 

--- a/components/editor/editor_ui.cpp
+++ b/components/editor/editor_ui.cpp
@@ -805,6 +805,19 @@ static lv_timer_t   *s_key_drain_timer = NULL;
  * intervals.  The repeat is cancelled on key-up. */
 #define KEY_REPEAT_DELAY_MS   500
 #define KEY_REPEAT_RATE_MS    50
+/* Safety net for a key-up that never arrives -- e.g. BLE boot-protocol
+ * report diffing (see process_key_array() in ble_keyboard.cpp) cannot
+ * always tell "still held" apart from "released and something else
+ * changed", so a lost key-up is a real, observed failure mode, not
+ * theoretical. Without this, a stuck-held key repeats forever: every
+ * KEY_REPEAT_RATE_MS re-injection on an e-paper board also triggers a
+ * display refresh, so a stuck key can permanently saturate the system
+ * and silently starve all later real keystrokes from ever being
+ * processed -- confirmed on real hardware as the editor's content
+ * freezing indefinitely (repeated identical redraws in the log, but
+ * the text the user kept typing afterward never appears at all). No
+ * human intentionally holds a key this long while typing. */
+#define KEY_REPEAT_MAX_MS     5000
 static kb_event_t s_repeat_ev    = {};      /* last key-down event */
 static bool       s_repeat_held  = false;   /* is a key currently held? */
 static uint32_t   s_repeat_start = 0;       /* tick when key was pressed */
@@ -2738,6 +2751,22 @@ extern "C" void editor_ui_show_file_browser(void)
     }
 
     sync_battery_labels();
+#if defined(CONFIG_DRAFTLING_DISPLAY_EPD)
+    /* This is the actual boot-time first screen on e-paper (the boot
+     * flow shows the file browser before the editor -- see
+     * editor_ui_init()). epd_full_screen_repaint() doesn't apply here:
+     * it only invalidates s_scr (the editor screen), not s_scr_browser,
+     * so it wouldn't force this screen's own widgets to redraw. Same
+     * underlying issue as the two lv_scr_load() call sites already
+     * fixed for the editor screen (apply_pending_connect_state()'s
+     * restore branch, editor_ui_show_editor()): a bare lv_scr_load()
+     * does not reliably force every child widget to redraw from a
+     * blank/stale framebuffer on this backend. Wipe the framebuffer
+     * and invalidate this screen explicitly instead of relying on
+     * lv_scr_load() alone. */
+    display_clear(0xFF);
+    lv_obj_invalidate(s_scr_browser);
+#endif
     lv_scr_load(s_scr_browser);
 }
 
@@ -2747,6 +2776,20 @@ extern "C" void editor_ui_show_editor(void)
     editor_set_mode(EDITOR_MODE_EDITING);
     sync_battery_labels();
     lv_scr_load(s_scr);
+#if defined(CONFIG_DRAFTLING_DISPLAY_EPD)
+    /* This is the actual boot-time path into the editor on e-paper --
+     * the boot flow shows the file browser first (see editor_ui_init()),
+     * so this runs on the very first file/new-file pick of a session,
+     * not apply_pending_connect_state()'s "restore" branch (which only
+     * applies to a *second* connect after the editor was already
+     * showing). Same missing-repaint bug: refresh_active_pane()'s
+     * per-line cache and update_title_bar()'s s_prev_title are not
+     * reset by a bare lv_scr_load()+editor_ui_refresh(), so a screen
+     * that starts blank (as s_scr does before its first real paint)
+     * stays blank until something else forces a full redraw. Matches
+     * the fix already applied to apply_pending_connect_state(). */
+    epd_full_screen_repaint();
+#endif
     editor_ui_refresh();
 }
 
@@ -3042,6 +3085,16 @@ static void show_menu(void)
     s_menu_sel = 0;
     refresh_menu_items();
     sync_battery_labels();
+#if defined(CONFIG_DRAFTLING_DISPLAY_EPD)
+    /* Same missing-repaint bug already fixed for the editor, file
+     * browser, and BLE-prompt-restore screen transitions: a bare
+     * lv_scr_load() does not reliably force this screen's widgets to
+     * redraw from a stale framebuffer on this backend.
+     * epd_full_screen_repaint() doesn't apply here -- it only
+     * invalidates s_scr (the editor screen), not s_scr_menu. */
+    display_clear(0xFF);
+    lv_obj_invalidate(s_scr_menu);
+#endif
     lv_scr_load(s_scr_menu);
 }
 
@@ -3256,6 +3309,11 @@ static void show_settings(void)
 #endif
     refresh_settings_items();
     sync_battery_labels();
+#if defined(CONFIG_DRAFTLING_DISPLAY_EPD)
+    /* Same missing-repaint bug as show_menu() -- see its comment. */
+    display_clear(0xFF);
+    lv_obj_invalidate(s_scr_settings);
+#endif
     lv_scr_load(s_scr_settings);
 }
 
@@ -5354,6 +5412,15 @@ static void key_repeat_cb(lv_timer_t *timer)
     uint32_t now = xTaskGetTickCount();
     uint32_t elapsed = (now - s_repeat_start) * portTICK_PERIOD_MS;
 
+    /* See KEY_REPEAT_MAX_MS's comment: treat an implausibly long hold
+     * as a missed key-up rather than genuine input, and stop
+     * repeating instead of re-injecting this key forever. */
+    if (elapsed >= KEY_REPEAT_MAX_MS) {
+        s_repeat_held   = false;
+        s_repeat_firing = false;
+        return;
+    }
+
     if (!s_repeat_firing) {
         if (elapsed >= KEY_REPEAT_DELAY_MS) {
             s_repeat_firing = true;
@@ -5454,6 +5521,24 @@ static void apply_pending_connect_state(void)
                 /* Restore the editor -- file contents are still in
                  * the gap buffer; no need to close/reopen. */
                 lv_scr_load(s_scr);
+#if defined(CONFIG_DRAFTLING_DISPLAY_EPD)
+                /* On e-paper, refresh_active_pane()'s per-line cache
+                 * (s_prev_line_text[] etc) still holds whatever text
+                 * was last rendered before the BLE prompt screen took
+                 * over -- since the document did not change while
+                 * disconnected, that cache still matches, so
+                 * editor_ui_refresh() alone would skip re-calling
+                 * lv_label_set_text() for every line ("can_skip"),
+                 * leaving the panel blank until something else forces
+                 * a real redraw. Matches the same class of bug
+                 * epd_full_screen_repaint() already exists to fix for
+                 * the split-pane and font-change transitions -- use
+                 * it here too rather than the bare
+                 * display_request_full_refresh() above, which only
+                 * flags the next flush as full and does not touch
+                 * this cache. */
+                epd_full_screen_repaint();
+#endif
                 editor_ui_refresh();
             } else {
                 editor_ui_show_file_browser();
@@ -5513,6 +5598,12 @@ static void apply_pending_connect_state(void)
          * wait_until_release set, which silently absorbs taps
          * on the BLE prompt's "Off" button. */
         lv_indev_reset(NULL, NULL);
+#if defined(CONFIG_DRAFTLING_DISPLAY_EPD)
+        /* Same missing-repaint bug as show_menu()/show_settings() --
+         * see show_menu()'s comment. */
+        display_clear(0xFF);
+        lv_obj_invalidate(s_scr_ble_prompt);
+#endif
         lv_scr_load(s_scr_ble_prompt);
     }
 }

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -157,6 +157,24 @@ config DRAFTLING_MODEL_FREENOVE_FNK0104S
         deep-sleep wakeup source.
         See https://github.com/Freenove/Freenove_ESP32_S3_Display
 
+config DRAFTLING_MODEL_ELECROW_CROWPANEL_579
+    bool "Elecrow CrowPanel ESP32-S3 5.79\" E-Paper HMI (SSD1683 x2, 792x272)"
+    depends on IDF_TARGET_ESP32S3
+    help
+        Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI Display: 792x272
+        black/white e-paper panel built from two SSD1683 controllers
+        (one per half), driven over plain SPI by
+        components/display/display_ssd1683.cpp. On-board MicroSD on
+        a dedicated SPI bus. A Menu button (GPIO2) is the deep-sleep
+        wake source and doubles as F1 (open/close the Settings menu)
+        on short press / "forget all BLE keyboards" on a 2 s hold. A
+        Back button plus a 3-way dial switch (Up/Down/OK) provide
+        full menu navigation (Esc / arrow keys / Enter) without a
+        keyboard. No on-board battery monitor.
+
+        This board has been added without on-hardware testing; see
+        HARDWARE.md.
+
 endchoice
 
 # ---- Derived: display category (driven by hardware-model choice) ----
@@ -310,6 +328,7 @@ config DRAFTLING_DISPLAY_EPD
     default y if DRAFTLING_MODEL_M5STACK_PAPERS3
     default y if DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO
     default y if DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752
+    default y if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     default n
 
 # DRAFTLING_DISPLAY_EPDIY is set automatically when the selected
@@ -335,6 +354,18 @@ config DRAFTLING_DISPLAY_EPDIY
 config DRAFTLING_DISPLAY_H752_EPD
     bool
     default y if DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752
+    default n
+
+# DRAFTLING_DISPLAY_SSD1683 selects the from-scratch dual-controller
+# SPI e-paper backend for the Elecrow CrowPanel 5.79" E-Paper HMI
+# Display (components/display/display_ssd1683.cpp). The 792x272
+# panel is built from two SSD1683 driver chips (one per half); the
+# backend streams the framebuffer to each half through its own
+# windowed RAM-write command sequence, ported from the community
+# ESPHome driver at github.com/samperk1/esphome-crowpanel-579.
+config DRAFTLING_DISPLAY_SSD1683
+    bool
+    default y if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     default n
 
 # DRAFTLING_EPDIY_BOARD_PAPERS3 selects the in-tree PaperS3 board
@@ -659,6 +690,9 @@ config DRAFTLING_WAKEUP_GPIO
     default 0  if DRAFTLING_MODEL_FREENOVE_FNK0104A
     default 0  if DRAFTLING_MODEL_FREENOVE_FNK0104B
     default 0  if DRAFTLING_MODEL_FREENOVE_FNK0104S
+    # Elecrow CrowPanel 5.79" E-Paper HMI: Menu button on GPIO2
+    # (active-low, RTC-capable).
+    default 2  if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     default 0
 
 # ---- Touchscreen support ----
@@ -913,6 +947,7 @@ config DRAFTLING_DISPLAY_WIDTH
     default 320 if DRAFTLING_MODEL_FREENOVE_FNK0104A
     default 320 if DRAFTLING_MODEL_FREENOVE_FNK0104B
     default 480 if DRAFTLING_MODEL_FREENOVE_FNK0104S
+    default 792 if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     help
         Display width in pixels (derived). Driven by the hardware-model
         choice. Must be a multiple of 8 for e-paper backends.
@@ -933,6 +968,7 @@ config DRAFTLING_DISPLAY_HEIGHT
     default 240 if DRAFTLING_MODEL_FREENOVE_FNK0104A
     default 240 if DRAFTLING_MODEL_FREENOVE_FNK0104B
     default 320 if DRAFTLING_MODEL_FREENOVE_FNK0104S
+    default 272 if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     help
         Display height in pixels (derived). Driven by the hardware-model
         choice.

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -47,6 +47,8 @@
 #include "boards/freenove_fnk0104b.h"
 #elif defined(CONFIG_DRAFTLING_MODEL_FREENOVE_FNK0104S)
 #include "boards/freenove_fnk0104s.h"
+#elif defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
+#include "boards/elecrow_crowpanel_579.h"
 #else
 #error "No hardware model selected. Run idf.py menuconfig and choose a model."
 #endif

--- a/main/boards/elecrow_crowpanel_579.h
+++ b/main/boards/elecrow_crowpanel_579.h
@@ -1,0 +1,71 @@
+#pragma once
+/* ----- Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI Display -----
+ *
+ * ESP32-S3-WROOM-1-N8R8 (8 MB flash, 8 MB PSRAM) driving a 5.79"
+ * 792x272 black/white e-paper panel over plain SPI. The panel is
+ * built from two SSD1683 controllers, one per half (left/right),
+ * sharing a single SPI bus (CS/DC/RST/BUSY); the display backend
+ * (components/display/display_ssd1683.cpp) drives both halves with
+ * the dual-window command sequence ported from the community
+ * ESPHome driver at github.com/samperk1/esphome-crowpanel-579
+ * (reverse-engineered and photograph-verified against real
+ * hardware). All EPD panel GPIOs and the panel power-enable pin are
+ * hard-coded directly inside display_ssd1683.cpp -- this backend is
+ * used by exactly one board, matching the convention already used
+ * by display_ili9341.cpp / display_xteink_epd.cpp.
+ *
+ * Buttons: a Menu button (GPIO2) doubles as the deep-sleep wake
+ * source and, during normal operation, as an F1 (open/close the
+ * Settings menu) key on short press / "forget all BLE keyboards" on
+ * a 2 s hold -- see crowpanel_menu_key_init() in main.cpp (same
+ * convention as the LilyGO T5 E-Paper S3 Pro H752 side key). A Back
+ * button (GPIO1) and a 3-way dial switch (Up/Down/OK -- physically a
+ * rocker-style navigation switch on this board, not a rotary
+ * encoder) round out full menu navigation without a keyboard:
+ * Back -> Esc, dial Up/Down -> arrow keys, dial press (OK) -> Enter.
+ * See crowpanel_nav_init() in main.cpp.
+ *
+ * No on-board battery ADC or fuel gauge was found in the vendor
+ * Eagle schematic (net "BAT" is a bare JST connector with no
+ * resistive divider wired to any GPIO) or in any of the vendor's
+ * Arduino examples -- see HARDWARE.md.
+ *
+ * This board has been added without on-hardware testing. Pin
+ * assignments come from the vendor's Arduino examples and Eagle
+ * schematic (github.com/Elecrow-RD/CrowPanel-ESP32-5.79-E-paper-HMI-
+ * Display-with-272-792) cross-checked against the community ESPHome
+ * driver referenced above.
+ *
+ * Included by main/app_config.h when
+ * CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579 is selected.
+ */
+
+#define BOARD_NAME      "Elecrow CrowPanel ESP32-S3 5.79in E-Paper"
+
+/* SD card on its own 4-wire SPI bus, separate from the EPD panel's
+ * SPI bus. Power-enable line is active HIGH (IO42_TF_3.3_CTL on the
+ * vendor schematic; driven in main.cpp before sd_card_init_spi(),
+ * matching the vendor's 5.79_TF Arduino example). */
+#define SD_SPI_MOSI_PIN     40
+#define SD_SPI_MISO_PIN     13
+#define SD_SPI_SCK_PIN      39
+#define SD_SPI_CS_PIN       10
+#define SD_EN_PIN           -1
+#define SD_POWER_EN_PIN     42
+
+/* No on-board battery monitor (see the file-header comment above). */
+#define BATT_ADC_PIN        -1
+#define BATT_EN_PIN         -1
+#define BATT_DIVIDER        1
+
+/* Menu button: deep-sleep wake source (RTC-capable) and, while
+ * awake, the F1 / forget-keyboards key -- see
+ * crowpanel_menu_key_init() in main.cpp. */
+#define WAKEUP_GPIO_NUM     2
+
+/* Back button and 3-way dial switch (Up/Down/OK), all active-low
+ * with internal pull-ups -- see crowpanel_nav_init() in main.cpp. */
+#define BTN_BACK_PIN        1
+#define BTN_DIAL_UP_PIN     6
+#define BTN_DIAL_DOWN_PIN   4
+#define BTN_DIAL_OK_PIN     5

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -696,6 +696,28 @@ static void pre_sleep_h752_deinit(void)
 #endif /* CONFIG_DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752 */
 #endif /* LilyGO T5 EPD S3 family */
 
+#if defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
+static void pre_sleep_crowpanel_579_deinit(void)
+{
+    ESP_LOGI(TAG, "Pre-sleep: Elecrow CrowPanel 5.79in peripheral teardown");
+
+    pre_sleep_autosave();
+    (void)sd_card_deinit();
+
+    /* Cut the SD card's 3.3 V rail (IO42_TF_3.3_CTL) and latch it
+     * through deep sleep. Unlike the EPD panel rail (see
+     * display_deep_sleep_prepare() in display_ssd1683.cpp, which is
+     * deliberately left alone), there is no bistable image to
+     * preserve here -- the card was already cleanly unmounted above,
+     * so cutting its rail is safe and saves power. */
+    gpio_set_level((gpio_num_t)SD_POWER_EN_PIN, 0);
+    gpio_hold_en((gpio_num_t)SD_POWER_EN_PIN);
+    gpio_deep_sleep_hold_en();
+
+    display_deep_sleep_prepare();
+}
+#endif /* CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579 */
+
 /* Poll period and long-press threshold shared by the H752 side-key
  * handler and the generic wakeup-GPIO handler below. */
 #define BTN_POLL_PERIOD_MS    30
@@ -810,6 +832,168 @@ static void h752_user_key_init(void)
 }
 #endif /* CONFIG_DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752 */
 
+#if defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
+/* ---- CrowPanel 5.79in Menu button + Back button/dial switch ----
+ *
+ * This board has no touchscreen, so the four buttons below are the
+ * only way to drive the editor without a keyboard connected.
+ *
+ * The Menu button (GPIO2, also the deep-sleep wake source) doubles
+ * as an F1 key during normal operation, mirroring the LilyGO T5 Pro
+ * H752 side-key convention above: a short press injects F1 (open/
+ * close the Settings menu), a 2 s hold clears every stored BLE
+ * keyboard bond and starts a fresh scan. The synthetic event is
+ * injected as press+release in one go so the key-repeat tracker
+ * never fires a second toggle while the button is held.
+ *
+ * The Back button and the 3-way dial switch (Up/Down/OK -- a
+ * rocker-style navigation switch on this board, not a rotary
+ * encoder) round out full menu navigation once it is open: Back
+ * injects Esc (closes the menu / settings / prompts, and in the
+ * editor returns to the file browser), the dial's Up/Down positions
+ * inject the arrow keys, and pressing the dial (OK) injects Enter.
+ * All four are polled at 30 ms and injected on release.
+ *
+ * Debounce: field testing showed the H752-style two-sample (60 ms)
+ * debounce used elsewhere in this file is too short here -- a
+ * partial EPD refresh's current draw (the panel's high-voltage boost
+ * converter switching) can dip the logic rail enough to read as a
+ * brief button press on these lines, which only have the ESP32-S3's
+ * weak internal pull-up (~45 kohm) holding them idle. Because a
+ * refresh follows every keystroke, this shows up as spurious cursor
+ * movement or, worse, an accidental trip into the Settings menu's
+ * Keyboard Layout entry while typing. CROWPANEL_DEBOUNCE_SAMPLES
+ * requires 5 consecutive 30 ms samples (150 ms) of the new level
+ * before accepting it -- comfortably longer than the vendor's own
+ * factory-firmware debounce (100 ms, see the 5.79_key Arduino
+ * example) and any single boost-converter transient, while still
+ * well under normal human button-press duration. */
+#define CROWPANEL_DEBOUNCE_SAMPLES 5
+
+static void crowpanel_inject_key(uint8_t keycode)
+{
+    kb_event_t ev = {};
+    ev.keycode = keycode;
+    ev.pressed = true;
+    editor_ui_handle_key(&ev);
+    ev.pressed = false;
+    editor_ui_handle_key(&ev);
+}
+
+/* Poll period BTN_POLL_PERIOD_MS ms; BTN_LONG_PRESS_TICKS ticks = 2 s hold. */
+#define CROWPANEL_MENU_LONG_PRESS_TICKS BTN_LONG_PRESS_TICKS
+
+static void crowpanel_menu_key_poll_cb(void *arg)
+{
+    (void)arg;
+    static bool down             = false;
+    static int  stable           = 0;
+    static int  hold_ticks       = 0;
+    static bool long_press_fired = false;
+
+    bool raw_down = gpio_get_level((gpio_num_t)WAKEUP_GPIO_NUM) == 0;
+
+    if (raw_down == down) {
+        if (down) {
+            hold_ticks++;
+            if (!long_press_fired && hold_ticks >= CROWPANEL_MENU_LONG_PRESS_TICKS) {
+                long_press_fired = true;
+                ESP_LOGI(TAG, "CrowPanel Menu button: 2 s long press -- "
+                              "forgetting all keyboards (GPIO%d)",
+                         WAKEUP_GPIO_NUM);
+                ble_keyboard_forget_all();
+            }
+        }
+        stable = 0;
+        return;
+    }
+
+    if (++stable < CROWPANEL_DEBOUNCE_SAMPLES) return;
+
+    stable = 0;
+    down = raw_down;
+
+    if (down) {
+        hold_ticks       = 0;
+        long_press_fired = false;
+    } else {
+        if (!long_press_fired) {
+            crowpanel_inject_key(KB_KEY_F1);
+        }
+        hold_ticks       = 0;
+        long_press_fired = false;
+    }
+}
+
+static void crowpanel_menu_key_init(void)
+{
+    gpio_config_t g = {};
+    g.intr_type    = GPIO_INTR_DISABLE;
+    g.mode         = GPIO_MODE_INPUT;
+    g.pin_bit_mask = 1ULL << WAKEUP_GPIO_NUM;
+    g.pull_up_en   = GPIO_PULLUP_ENABLE;
+    g.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    gpio_config(&g);
+
+    esp_timer_create_args_t targs = {};
+    targs.callback = crowpanel_menu_key_poll_cb;
+    targs.name     = "crowpanel_menu";
+    esp_timer_handle_t t = NULL;
+    ESP_ERROR_CHECK(esp_timer_create(&targs, &t));
+    ESP_ERROR_CHECK(esp_timer_start_periodic(t, (uint64_t)BTN_POLL_PERIOD_MS * 1000));
+    ESP_LOGI(TAG, "CrowPanel Menu button poller started (GPIO%d)", WAKEUP_GPIO_NUM);
+}
+
+static void crowpanel_nav_poll_cb(void *arg)
+{
+    (void)arg;
+    static const struct { int pin; uint8_t keycode; } kButtons[] = {
+        { BTN_BACK_PIN,      KB_KEY_ESCAPE },
+        { BTN_DIAL_UP_PIN,   KB_KEY_UP },
+        { BTN_DIAL_DOWN_PIN, KB_KEY_DOWN },
+        { BTN_DIAL_OK_PIN,   KB_KEY_ENTER },
+    };
+    static bool down[4]   = { false, false, false, false };
+    static int  stable[4] = { 0, 0, 0, 0 };
+
+    for (int i = 0; i < 4; i++) {
+        bool raw_down = gpio_get_level((gpio_num_t)kButtons[i].pin) == 0;
+        if (raw_down == down[i]) {
+            stable[i] = 0;
+            continue;
+        }
+        if (++stable[i] < CROWPANEL_DEBOUNCE_SAMPLES) continue;
+        stable[i] = 0;
+        down[i] = raw_down;
+        if (!down[i]) {
+            crowpanel_inject_key(kButtons[i].keycode);
+        }
+    }
+}
+
+static void crowpanel_nav_init(void)
+{
+    gpio_config_t g = {};
+    g.intr_type    = GPIO_INTR_DISABLE;
+    g.mode         = GPIO_MODE_INPUT;
+    g.pin_bit_mask = (1ULL << BTN_BACK_PIN) | (1ULL << BTN_DIAL_UP_PIN) |
+                      (1ULL << BTN_DIAL_DOWN_PIN) | (1ULL << BTN_DIAL_OK_PIN);
+    g.pull_up_en   = GPIO_PULLUP_ENABLE;
+    g.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    gpio_config(&g);
+
+    esp_timer_create_args_t targs = {};
+    targs.callback = crowpanel_nav_poll_cb;
+    targs.name     = "crowpanel_nav";
+    esp_timer_handle_t t = NULL;
+    ESP_ERROR_CHECK(esp_timer_create(&targs, &t));
+    ESP_ERROR_CHECK(esp_timer_start_periodic(t, (uint64_t)BTN_POLL_PERIOD_MS * 1000));
+    ESP_LOGI(TAG, "CrowPanel Back/dial-switch poller started "
+                  "(Back=GPIO%d, Up=GPIO%d, Down=GPIO%d, OK=GPIO%d)",
+             BTN_BACK_PIN, BTN_DIAL_UP_PIN, BTN_DIAL_DOWN_PIN, BTN_DIAL_OK_PIN);
+}
+#endif /* CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579 */
+
 /* ---- Generic wakeup-GPIO long-press handler ----
  *
  * On boards other than the H752 (which has its own key handler above)
@@ -821,7 +1005,8 @@ static void h752_user_key_init(void)
  * The button is assumed to be active-low with the internal pull-up
  * enabled (the same electrical assumption the standby component makes
  * when it arms the EXT0 deep-sleep wake source on GPIO 0 / 18). */
-#if !defined(CONFIG_DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752)
+#if !defined(CONFIG_DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752) && \
+    !defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
 
 /* Poll period BTN_POLL_PERIOD_MS ms; BTN_LONG_PRESS_TICKS ticks = 2 s hold. */
 #define WAKEUP_BTN_LONG_PRESS_TICKS BTN_LONG_PRESS_TICKS
@@ -887,7 +1072,8 @@ static void wakeup_btn_init(void)
              WAKEUP_GPIO_NUM,
              gpio_get_level((gpio_num_t)WAKEUP_GPIO_NUM));
 }
-#endif /* !CONFIG_DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752 */
+#endif /* !CONFIG_DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752 &&
+        * !CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579 */
 
 #if defined(CONFIG_DRAFTLING_MODEL_M5STACK_TAB5)
 /* M5Stack Tab5 (ESP32-P4): pre-sleep peripheral teardown.
@@ -1264,6 +1450,12 @@ extern "C" void app_main(void)
      * inside display_ili9341.cpp since every FNK0104 SPI-TFT SKU
      * shares the same pinout. Pin parameters are ignored. */
     display_init(-1, -1, -1, -1, -1, -1, DISPLAY_WIDTH, DISPLAY_HEIGHT);
+#elif defined(CONFIG_DRAFTLING_DISPLAY_SSD1683)
+    /* Elecrow CrowPanel 5.79in E-Paper HMI. Dual-SSD1683 SPI panel;
+     * all panel GPIOs and the panel power-enable pin are hard-coded
+     * inside display_ssd1683.cpp since this backend is used by
+     * exactly one board. Pin parameters are ignored. */
+    display_init(-1, -1, -1, -1, -1, -1, DISPLAY_WIDTH, DISPLAY_HEIGHT);
 #elif defined(CONFIG_DRAFTLING_DISPLAY_AXS15231B)
     /* AXS15231B QSPI color LCD. Needs 9 GPIOs (CS/SCK/D0..D3/RST/TE/BL),
      * which do not fit in display_init()'s 6 pin slots, so the backend
@@ -1466,6 +1658,25 @@ extern "C" void app_main(void)
      * sd_card_init_spi() returns gracefully if no card is present. */
 #if defined(CONFIG_DRAFTLING_HAS_CH422G) && defined(CH422G_SD_CS_PIN)
     ch422g_set_pin(CH422G_SD_CS_PIN, false);
+#endif
+#if defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
+    /* SD slot power-enable, active HIGH (IO42_TF_3.3_CTL on the
+     * vendor schematic). Drive it before mounting -- see the vendor's
+     * 5.79_TF Arduino example (digitalWrite(42, HIGH)). Release any
+     * hold left by pre_sleep_crowpanel_579_deinit() first -- on
+     * ESP32-S3 a gpio_deep_sleep_hold_en() latch survives the wake
+     * reset and keeps the pad clamped low until software releases it
+     * (same pattern as the EPD panel power pin in
+     * display_ssd1683.cpp's display_init()). */
+    {
+        gpio_hold_dis((gpio_num_t)SD_POWER_EN_PIN);
+        gpio_config_t sd_pwr = {};
+        sd_pwr.intr_type    = GPIO_INTR_DISABLE;
+        sd_pwr.mode         = GPIO_MODE_OUTPUT;
+        sd_pwr.pin_bit_mask = (1ULL << SD_POWER_EN_PIN);
+        gpio_config(&sd_pwr);
+        gpio_set_level((gpio_num_t)SD_POWER_EN_PIN, 1);
+    }
 #endif
     sd_ret = sd_card_init_spi(SD_SPI_HOST_NUM,
                               SD_SPI_MISO_PIN, SD_SPI_MOSI_PIN, SD_SPI_SCK_PIN,
@@ -1884,6 +2095,13 @@ extern "C" void app_main(void)
     /* Side key (GPIO48) = Menu (F1) on short press,
      * forget all keyboards on 2 s long press. */
     h752_user_key_init();
+#elif defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
+    /* Menu button (GPIO2) = F1 on short press, forget all keyboards
+     * on 2 s long press (same convention as the H752 side key
+     * above). Back button + dial switch (Esc/Up/Down/Enter) handle
+     * the rest of menu navigation once it is open. */
+    crowpanel_menu_key_init();
+    crowpanel_nav_init();
 #else
     /* Generic wakeup-button long-press monitor: hold 2 s to forget
      * all stored BLE keyboard pairings and start a fresh scan. */
@@ -1910,6 +2128,8 @@ extern "C" void app_main(void)
     standby_set_pre_sleep_cb(pre_sleep_h752_deinit);
 #elif defined(CONFIG_DRAFTLING_MODEL_M5STACK_TAB5)
     standby_set_pre_sleep_cb(pre_sleep_tab5_deinit);
+#elif defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
+    standby_set_pre_sleep_cb(pre_sleep_crowpanel_579_deinit);
 #else
     standby_set_pre_sleep_cb(pre_sleep_autosave);
 #endif

--- a/partitions_8mb.csv
+++ b/partitions_8mb.csv
@@ -1,0 +1,11 @@
+# Variant of partitions.csv sized for 8 MB flash instead of 16 MB --
+# used only by the Elecrow CrowPanel ESP32-S3 5.79in E-Paper HMI Display
+# (ESP32-S3-WROOM-1-N8R8: 8 MB flash, 8 MB PSRAM), the only board so
+# far whose module has less than 16 MB of flash. factory is sized to
+# 0x780000 (7.5 MB), well clear of the current ~2 MB firmware image
+# while leaving the 8 MB chip fully addressable.
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     ,        0x6000,
+phy_init, data, phy,     ,        0x1000,
+factory,  app,  factory, ,        0x780000,
+nvs_keys, data, nvs_keys,,        0x1000,

--- a/sdkconfig.defaults.elecrow_crowpanel_579
+++ b/sdkconfig.defaults.elecrow_crowpanel_579
@@ -1,0 +1,30 @@
+# CMakePresets.json board defaults: Elecrow CrowPanel ESP32-S3 5.79in E-Paper HMI
+# Sets the hardware model and IDF target used by the "elecrow_crowpanel_579" preset.
+
+CONFIG_IDF_TARGET="esp32s3"
+CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579=y
+
+# This board's module is an ESP32-S3-WROOM-1-N8R8 (8 MB flash, 8 MB
+# PSRAM) -- unlike every other supported board, which has 16 MB of
+# flash. Override both the flash size (sdkconfig.defaults /
+# sdkconfig.defaults.esp32s3 default to 16 MB) and the custom
+# partition table (the shared partitions.csv sizes its factory app
+# partition at 14 MB, which does not fit in 8 MB flash at all) to a
+# smaller variant. Without this the app image header claims 16 MB and
+# the bootloader aborts at boot with "Detected size(8192k) smaller
+# than the size in the binary image header(16384k). Probe failed."
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_8mb.csv"
+
+# This board previously overrode the shared EPD default (every 30
+# partials) down to every 5, because partial refresh itself was
+# unreliable and degraded visible content within single-digit
+# keystrokes (see PR #47's history). Root cause since found and fixed:
+# a single Master Activation trigger could leave an incomplete pixel
+# transition, independent of RAM content or waveform; display_ssd1683.cpp
+# now runs every refresh (partial and full) twice back-to-back, which
+# reliably completes it. With that fixed, and every refresh already
+# rewriting the panel's entire RAM (not just the touched region) on
+# every call, the original justification for a shorter interval no
+# longer applies -- back to the shared default (see HARDWARE.md's
+# CrowPanel section for the full history).


### PR DESCRIPTION
## Summary
- Adds a new dual-controller SPI e-paper backend (`components/display/display_ssd1683.cpp`) for the Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI Display (792x272, two SSD1683 driver chips, one per half). Windowing math, seam-alignment handling and the "reset Old RAM to all-black after a full refresh" workaround are ported from the community ESPHome driver at [samperk1/esphome-crowpanel-579](https://github.com/samperk1/esphome-crowpanel-579), which reverse-engineered and photograph-verified the command sequences against real hardware.
- Menu button (GPIO2) is the deep-sleep wake source and doubles as F1 (open Settings) on short press / forget-all-BLE-keyboards on a 2s hold, mirroring the existing LilyGO T5 Pro H752 side-key convention. Back button + 3-way dial switch (Up/Down/OK) inject Esc/arrows/Enter, giving full menu navigation with no keyboard attached.
- No on-board battery ADC or fuel gauge is wired (verified against the vendor's Eagle schematic), so the battery indicator is unavailable on this board.
- This board has been added **without on-hardware testing**; see HARDWARE.md.

Built with conventions consistent with the still-open #43 (Xteink X4 Pro) so the two should combine as mostly independent append-only diffs when it merges.

## Test plan
- [x] `idf.py --preset elecrow_crowpanel_579 build` succeeds with zero warnings in the new code
- [x] Spot-checked `waveshare_rlcd42`, `lilygo_t5_epd_s3_pro_h752`, `jc3248w535` still build clean (no regressions in shared `main.cpp` / `Kconfig.projbuild` paths)
- [ ] On-hardware verification (not available to this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJ1LHbJKkS4USEJLJGVCgy