### PR TITLE
Fix Xteink X4 Pro touch orientation (180-degree flip)

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -280,8 +280,11 @@ Both functions now stream the OLD-plane's constant white fill from a
 separate, never-mutated buffer instead of reusing the NEW-plane's
 scratch buffer. The GT911 touch orientation (`TOUCH_SWAP_XY` /
 `TOUCH_MIRROR_X` / `TOUCH_MIRROR_Y` in `main/boards/xteink_x4_pro.h`)
-is still a best-effort starting point and may need a dial-in pass
-with `CONFIG_DRAFTLING_TOUCH_DEBUG_LOG`.
+has since been dialed in against a physical unit with
+`CONFIG_DRAFTLING_TOUCH_DEBUG_LOG`: the FreeInk SDK's starting values
+(`swapXY=true, flipY=true`) had touches landing 180 degrees opposite
+of where the finger was; `TOUCH_MIRROR_X`/`TOUCH_MIRROR_Y` are now 1/0
+(swapped from the initial 0/1) to correct it.
 
 ## Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI Display
 

--- a/components/touchscreen/touchscreen.cpp
+++ b/components/touchscreen/touchscreen.cpp
@@ -398,6 +398,16 @@ static bool poll_gt911(int *out_x, int *out_y)
             if (out_x) *out_x = lx;
             if (out_y) *out_y = ly;
             pressed = true;
+#if defined(CONFIG_DRAFTLING_TOUCH_DEBUG_LOG)
+            /* Diagnostic log: raw native coordinates read from the
+             * GT911 and the logical coordinates handed to LVGL after
+             * native_to_logical(). Used to dial in TOUCH_SWAP_XY /
+             * TOUCH_MIRROR_* on new boards. Gated behind
+             * DRAFTLING_TOUCH_DEBUG_LOG (off by default) so the logs
+             * do not spam the console during normal use. */
+            ESP_LOGI(TAG, "gt911 raw=(%d,%d) status=0x%02X -> logical=(%d,%d)",
+                     nx, ny, status, lx, ly);
+#endif
         } else {
             ESP_LOGD(TAG, "gt911 point read failed");
         }
@@ -694,12 +704,25 @@ extern "C" void touchscreen_init(const touchscreen_config_t *cfg)
         uint8_t primary = s_cfg.i2c_addr;
         uint8_t alt     = (primary == 0x5D) ? 0x14 :
                           (primary == 0x14) ? 0x5D : primary;
-        if (i2c_master_probe(s_bus, primary, 100) != ESP_OK &&
-            alt != primary &&
+        bool primary_ok = i2c_master_probe(s_bus, primary, 100) == ESP_OK;
+        if (!primary_ok && alt != primary &&
             i2c_master_probe(s_bus, alt, 100) == ESP_OK) {
             ESP_LOGI(TAG, "GT911 responded at 0x%02X (configured 0x%02X)",
                      alt, primary);
             s_cfg.i2c_addr = alt;
+        } else if (!primary_ok && alt == s_cfg.i2c_addr) {
+            /* Neither the configured address nor the alternate ACK'd.
+             * We still proceed to add the I2C device below (driver-NG
+             * add_device does not itself talk to the bus), and the
+             * "touchscreen initialized" log further down will print
+             * regardless -- without this warning that log would look
+             * like a clean bring-up even though the controller never
+             * answered, which is exactly the failure mode this line
+             * is here to surface. */
+            ESP_LOGW(TAG, "GT911 did not respond at 0x%02X or 0x%02X -- "
+                          "check TOUCH_POWER_EN_PIN / I2C wiring / power "
+                          "sequencing; touch will not work",
+                     primary, alt);
         }
     }
 #endif

--- a/main/boards/xteink_x4_pro.h
+++ b/main/boards/xteink_x4_pro.h
@@ -11,8 +11,8 @@
  * Pin assignments, register sequences and waveform timing come from
  * the FreeInk SDK (https://github.com/Free-Ink/freeink-sdk, MIT
  * licensed), which reverse-engineered the OEM firmware's exact
- * register values. This board has NOT been tested on physical
- * hardware (same caveat as the M5Stack Tab5 entry in HARDWARE.md).
+ * register values. This board has been tested on physical hardware
+ * (see HARDWARE.md for the on-hardware bring-up notes).
  *
  * Included by main/app_config.h when
  * CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO is selected.
@@ -47,11 +47,16 @@
  * touchscreen_config_t field for this, so main.cpp drives it directly
  * as a one-off GPIO poke (same style as the LilyGO LoRa-CS drive).
  *
- * Native orientation (swap_xy=1, mirror_y=1) is carried over from the
- * FreeInk SDK's GT911 config for this board (swapXY=true, flipY=true)
- * as a best-effort starting point -- like every other new touch
- * board, it may need a dial-in pass with
- * CONFIG_DRAFTLING_TOUCH_DEBUG_LOG on real hardware. */
+ * The FreeInk SDK's GT911 config (swapXY=true, flipY=true) was used
+ * as a best-effort starting point but was 180 degrees off on real
+ * hardware -- CONFIG_DRAFTLING_TOUCH_DEBUG_LOG raw/logical coordinate
+ * logging on a physical unit showed every corner tap landing at its
+ * diagonal opposite (e.g. a physical top-left tap reporting as
+ * logical bottom-right). swap_xy=1 was correct (native X tracks the
+ * panel's top/bottom, native Y tracks left/right, confirming the
+ * native panel is mounted portrait under a landscape UI); mirroring
+ * the other axis of the pair (X instead of Y) is what corrects the
+ * 180-degree flip. */
 #define TOUCH_I2C_ADDR      0x5D
 #define TOUCH_INT_PIN       CONFIG_DRAFTLING_TOUCH_INT_GPIO
 #define TOUCH_RST_PIN       CONFIG_DRAFTLING_TOUCH_RST_GPIO
@@ -59,8 +64,8 @@
 #define TOUCH_NATIVE_W      480
 #define TOUCH_NATIVE_H      800
 #define TOUCH_SWAP_XY       1
-#define TOUCH_MIRROR_X      0
-#define TOUCH_MIRROR_Y      1
+#define TOUCH_MIRROR_X      1
+#define TOUCH_MIRROR_Y      0
 
 /* CW2017 fuel gauge, on the shared I2C bus above. No charger IC on
  * this bus, so charging state is reported as unknown. */


### PR DESCRIPTION
## Summary
- The Xteink X4 Pro's GT911 touch orientation flags (`TOUCH_MIRROR_X`/`TOUCH_MIRROR_Y` in `main/boards/xteink_x4_pro.h`) were carried over from the FreeInk SDK as an untested starting point. On real hardware, every touch landed at its diagonal opposite (top-left tap → reported bottom-right, etc.) — a 180-degree flip. `TOUCH_SWAP_XY=1` was correct; swapping which axis is mirrored (`TOUCH_MIRROR_X` 0→1, `TOUCH_MIRROR_Y` 1→0) fixes it. Confirmed working on physical hardware.
- `CONFIG_DRAFTLING_TOUCH_DEBUG_LOG` was documented as the tool for dialing in GT911 orientation, but only had an implementation on the M5Stack Tab5 BSP path. Added the same raw/logical coordinate logging to `poll_gt911()` in `components/touchscreen/touchscreen.cpp` so future GT911-based board bring-up has it too, plus a warning when the GT911 doesn't ACK at either I2C address during init (previously silent).
- Updated stale doc comments in `main/boards/xteink_x4_pro.h` and `HARDWARE.md` that predated on-hardware testing.

## Test plan
- [x] `idf.py build` succeeds for the `xteink_x4_pro` target
- [x] User confirmed touch now tracks correctly across the panel on physical hardware after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HZAME2PDxBMnz5cEYoq95