### PR TITLE
Active language layouts setting + fix Ctrl shortcuts for non-US layouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,14 +570,38 @@ Public API: `ch422g_init()`, `ch422g_set_pin()`.
 
 Translates HID keycodes and modifier flags into UTF-8 character strings
 for the active keyboard layout. Supports US-English (QWERTY), Ukrainian
-(Cyrillic), German (QWERTZ), and French (AZERTY). Each layout can be
-independently enabled or disabled at build time via Kconfig (see
-`components/kb_layout/Kconfig.projbuild`). The active layout is cycled
-at runtime with `kb_layout_next()` (bound to `Ctrl+L` and `Win+Space`
-in the editor).
+(Cyrillic), German (QWERTZ), French (AZERTY), and Hebrew (SI 1452, RTL
+via LVGL's bidi engine). Each layout can be independently enabled or
+disabled at build time via Kconfig (see
+`components/kb_layout/Kconfig.projbuild`); all five default to enabled.
 
-Public API: `kb_layout_translate()`, `kb_layout_set()`, `kb_layout_get()`,
-`kb_layout_name()`, `kb_layout_next()`.
+Which of the compiled-in layouts `kb_layout_next()` (bound to `Ctrl+L`
+and `Win+Space` in the editor) actually cycles through is a separate,
+user-configurable "active set" -- see `kb_layout_set_active()` /
+`kb_layout_is_active()` / `kb_layout_get_active_mask()` /
+`kb_layout_set_active_mask()`. `components/editor/editor_ui.cpp` owns
+persisting this set to NVS and exposes it as the "Active layouts" row
+in the F1 -> Settings menu; it defaults to US + UA. The title bar only
+shows the `[XX]` layout tag when `kb_layout_active_count() > 1`.
+
+Ctrl-letter shortcuts (`handle_editor_key()` / `handle_browser_key()`
+in `editor_ui.cpp`) and the file browser's unmodified `N` (new file)
+accelerator resolve their letter via `kb_layout_shortcut_char()`, not
+a raw `kb_layout_translate()` call: under a Latin layout (US/DE/FR) it
+follows the national layout, and is not limited to the classic 26-key
+US letter block -- so Ctrl+Z lands on the key printed "Z" on a German
+keyboard, and Ctrl+M on a French (AZERTY) keyboard is the semicolon
+key, since AZERTY moves "m" there. Under a non-Latin layout
+(Ukrainian/Hebrew) it falls back to the US physical key position
+within that classic block, since there is no national Latin letter to
+remap to. Plain document text entry still goes through
+`kb_layout_translate()` directly.
+
+Public API: `kb_layout_translate()`, `kb_layout_shortcut_char()`,
+`kb_layout_set()`, `kb_layout_get()`, `kb_layout_name()`,
+`kb_layout_next()`, `kb_layout_is_rtl()`, `kb_layout_is_active()`,
+`kb_layout_set_active()`, `kb_layout_active_count()`,
+`kb_layout_get_active_mask()`, `kb_layout_set_active_mask()`.
 
 ### components/sd_card/
 
@@ -1130,13 +1154,21 @@ is an independent `bool` option that can be enabled or disabled:
 |--------|--------|---------|
 | KB_LAYOUT_ENABLE_US | US-English (QWERTY) | y (enabled) |
 | KB_LAYOUT_ENABLE_UA | Ukrainian (Cyrillic) | y (enabled) |
-| KB_LAYOUT_ENABLE_DE | German (QWERTZ) | n (disabled) |
-| KB_LAYOUT_ENABLE_FR | French (AZERTY) | n (disabled) |
+| KB_LAYOUT_ENABLE_DE | German (QWERTZ) | y (enabled) |
+| KB_LAYOUT_ENABLE_FR | French (AZERTY) | y (enabled) |
+| KB_LAYOUT_ENABLE_HE | Hebrew (SI 1452) | y (enabled) |
 
 Disabling unused layouts saves flash space because the translation
 tables for disabled layouts are excluded from the build. The `kb_layout`
 component reads these symbols at compile time to conditionally compile
-only the enabled layout tables.
+only the enabled layout tables. A board-specific `sdkconfig.defaults.*`
+can override individual symbols (see `sdkconfig.defaults.sunton_8048s043`,
+which keeps only US + DE for that author's German keyboard).
+
+Which of the *compiled-in* layouts actually get cycled through at
+runtime is a separate, user-facing "Active layouts" setting (F1 ->
+Settings), independent of this Kconfig menu -- see the `kb_layout`
+component writeup above.
 
 ## Building
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable user-facing changes to Draftling are recorded here, starting
+from the first published release (`v1.0.1`). Older history is available
+in the git log.
+
+## [Unreleased]
+
+### Added
+
+- **Active language layouts** setting (F1 -> Settings -> "Active
+  layouts"): choose which of the compiled-in keyboard layouts Ctrl+L /
+  Win+Space rotate through, instead of always cycling every layout
+  enabled in the firmware build. Defaults to US and UA. The title bar
+  only shows the current layout's name when more than one layout is
+  active, since there is nothing to switch to otherwise. In the picker,
+  Space toggles the highlighted layout the same as Enter.
+- All five keyboard layouts (US, UA, DE, FR, HE) are now enabled by
+  default in `idf.py menuconfig` (`DRAFTLING Keyboard Layouts`);
+  previously only US and UA were on by default.
+
+### Fixed
+
+- Ctrl-letter shortcuts (and the file browser's unmodified "N: New
+  file" key) no longer silently stop working when a non-Latin layout
+  (Ukrainian, Hebrew) is active -- they now resolve to the same US
+  physical key position as if the US layout were selected. Under a
+  Latin layout (German, French) they instead resolve to whatever
+  letter that physical key produces on the national layout, even when
+  that letter has moved off the classic US letter-key block: Ctrl+Z
+  lands on the key printed "Z" on a German (QWERTZ) keyboard, and
+  Ctrl+M on a French (AZERTY) keyboard is the semicolon key, since
+  AZERTY moves "m" there.
+
+## [1.0.1] - first release
+
+Baseline release. See git history up to tag `v1.0.1` for everything
+included.

--- a/firmware/components/editor/editor_ui.cpp
+++ b/firmware/components/editor/editor_ui.cpp
@@ -556,6 +556,38 @@ static void save_append_only_to_nvs(void)
     }
 }
 
+/* ---- Active language layouts ----
+ * Toggled from the F1 -> Settings menu and persisted in NVS. Selects
+ * which of the compiled-in keyboard layouts (see kb_layout.h) Ctrl+L /
+ * Win+Space rotate through -- a build with several layouts enabled in
+ * Kconfig does not force every user to page through all of them just
+ * to get back to the one or two they actually use. Defaults to US and
+ * UA (see kb_layout.cpp's default_active_mask()). The mask itself is
+ * owned by kb_layout.cpp; this is just the NVS load/save wrapper. */
+#define NVS_KEY_ACTIVE_LAYOUTS "actlayouts"
+
+static void load_active_layouts_from_nvs(void)
+{
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS_EDITOR, NVS_READONLY, &h) == ESP_OK) {
+        uint32_t v = 0;
+        if (nvs_get_u32(h, NVS_KEY_ACTIVE_LAYOUTS, &v) == ESP_OK) {
+            kb_layout_set_active_mask(v);
+        }
+        nvs_close(h);
+    }
+}
+
+static void save_active_layouts_to_nvs(void)
+{
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS_EDITOR, NVS_READWRITE, &h) == ESP_OK) {
+        nvs_set_u32(h, NVS_KEY_ACTIVE_LAYOUTS, kb_layout_get_active_mask());
+        nvs_commit(h);
+        nvs_close(h);
+    }
+}
+
 /* ---- Screen margins ----
  * Pixels of physical panel hidden under an opaque bezel/enclosure
  * cover on each edge (main/app_config.h's DISPLAY_LOGICAL_WIDTH/
@@ -742,6 +774,16 @@ static bool s_theme_picker_open      = false;
 static int  s_theme_picker_sel       = 0;
 static int  s_theme_picker_sel_prev  = -1;
 #endif
+
+/* Active-language-layouts picker overlay (shares s_scr_settings /
+ * s_settings_list, shown in place of the regular settings list while
+ * open). One checklist row per compiled-in layout plus a "Done" row;
+ * Enter toggles the highlighted layout in/out of the active set
+ * immediately (no separate confirm step, mirroring Append-only /
+ * Rotate / Invert). */
+static bool s_layouts_picker_open      = false;
+static int  s_layouts_picker_sel       = 0;
+static int  s_layouts_picker_sel_prev  = -1;
 
 /* Passkey overlay objects */
 static lv_obj_t *s_passkey_panel = NULL;
@@ -1409,21 +1451,29 @@ static void update_title_bar(void)
     int line, col;
     editor_get_cursor_pos(&line, &col);
     int total_lines = editor_get_line_count();
+    /* Only worth telling the user which layout is active when there is
+     * more than one in the active set to rotate through (see the
+     * "Active language layouts" setting) -- with a single active
+     * layout Ctrl+L has nothing to switch to, so the tag would just be
+     * noise in the title bar. */
+    char layout_tag[16] = "";
+    if (kb_layout_active_count() > 1) {
+        snprintf(layout_tag, sizeof(layout_tag), "  [%s]",
+                 kb_layout_name(kb_layout_get()));
+    }
 #if defined(CONFIG_DRAFTLING_DISPLAY_EPD)
     /* On e-paper boards the cursor moves on every keystroke, so the
      * column counter is omitted to avoid dirtying the title bar on
      * every edit. The line counter ("L %d/%d") only changes when the
      * cursor moves to a different line, so the s_prev_title cache
      * below collapses no-op redraws back to a single update. */
-    snprintf(buf, sizeof(buf), "%s%s  L %d/%d  [%s]",
+    snprintf(buf, sizeof(buf), "%s%s  L %d/%d%s",
              name, editor_is_modified() ? " *" : "",
-             line + 1, total_lines,
-             kb_layout_name(kb_layout_get()));
+             line + 1, total_lines, layout_tag);
 #else
-    snprintf(buf, sizeof(buf), "%s%s  L %d/%d C:%d  [%s]",
+    snprintf(buf, sizeof(buf), "%s%s  L %d/%d C:%d%s",
              name, editor_is_modified() ? " *" : "",
-             line + 1, total_lines, col + 1,
-             kb_layout_name(kb_layout_get()));
+             line + 1, total_lines, col + 1, layout_tag);
 #endif
 
     /* lv_label_set_text() in LVGL v9 unconditionally invalidates the
@@ -3231,14 +3281,15 @@ static int find_timeout_option(uint32_t sec)
 #define _SETTINGS_NEXT_AFTER_INVERT (_SETTINGS_NEXT_AFTER_ROTATE + 0)
 #endif
 #define SETTINGS_IDX_APPEND_ONLY   (_SETTINGS_NEXT_AFTER_INVERT + 0)
-#define SETTINGS_IDX_MARGIN_LEFT   (_SETTINGS_NEXT_AFTER_INVERT + 1)
-#define SETTINGS_IDX_MARGIN_RIGHT  (_SETTINGS_NEXT_AFTER_INVERT + 2)
-#define SETTINGS_IDX_MARGIN_TOP    (_SETTINGS_NEXT_AFTER_INVERT + 3)
-#define SETTINGS_IDX_MARGIN_BOTTOM (_SETTINGS_NEXT_AFTER_INVERT + 4)
-#define SETTINGS_IDX_SLEEP    (_SETTINGS_NEXT_AFTER_INVERT + 5)
-#define SETTINGS_IDX_RESET    (_SETTINGS_NEXT_AFTER_INVERT + 6)
-#define SETTINGS_IDX_BACK     (_SETTINGS_NEXT_AFTER_INVERT + 7)
-#define SETTINGS_ITEM_COUNT   (_SETTINGS_NEXT_AFTER_INVERT + 8)
+#define SETTINGS_IDX_LAYOUTS       (_SETTINGS_NEXT_AFTER_INVERT + 1)
+#define SETTINGS_IDX_MARGIN_LEFT   (_SETTINGS_NEXT_AFTER_INVERT + 2)
+#define SETTINGS_IDX_MARGIN_RIGHT  (_SETTINGS_NEXT_AFTER_INVERT + 3)
+#define SETTINGS_IDX_MARGIN_TOP    (_SETTINGS_NEXT_AFTER_INVERT + 4)
+#define SETTINGS_IDX_MARGIN_BOTTOM (_SETTINGS_NEXT_AFTER_INVERT + 5)
+#define SETTINGS_IDX_SLEEP    (_SETTINGS_NEXT_AFTER_INVERT + 6)
+#define SETTINGS_IDX_RESET    (_SETTINGS_NEXT_AFTER_INVERT + 7)
+#define SETTINGS_IDX_BACK     (_SETTINGS_NEXT_AFTER_INVERT + 8)
+#define SETTINGS_ITEM_COUNT   (_SETTINGS_NEXT_AFTER_INVERT + 9)
 
 static void refresh_settings_items(void)
 {
@@ -3302,6 +3353,20 @@ static void refresh_settings_items(void)
     snprintf(buf, sizeof(buf), "Append-only editing: %s",
              s_append_only ? "on" : "off");
     lv_list_add_btn(s_settings_list, NULL, buf);
+
+    /* Active language layouts -- comma-separated summary of the
+     * layouts Ctrl+L / Win+Space currently rotate through. */
+    {
+        char names[64] = "";
+        for (int i = 0; i < KB_LAYOUT_COUNT; i++) {
+            kb_layout_id_t id = (kb_layout_id_t)i;
+            if (!kb_layout_is_active(id)) continue;
+            if (names[0]) strncat(names, ", ", sizeof(names) - strlen(names) - 1);
+            strncat(names, kb_layout_name(id), sizeof(names) - strlen(names) - 1);
+        }
+        snprintf(buf, sizeof(buf), "Active layouts: %s (Enter to edit)", names);
+        lv_list_add_btn(s_settings_list, NULL, buf);
+    }
 
     /* Screen margins -- pixels of panel hidden under the enclosure on
      * each edge. Zero by default; the LVGL display resolution is fixed
@@ -3389,6 +3454,45 @@ static void close_theme_picker(void)
 }
 #endif
 
+/* ---- Active-language-layouts picker ----
+ * Renders one checklist row per compiled-in layout into the same
+ * s_settings_list widget while s_layouts_picker_open is true, plus a
+ * trailing "Done" row. Unlike the theme picker, Enter toggles the
+ * highlighted row's membership in the active set immediately (applied
+ * and persisted on the spot) rather than picking one value and
+ * confirming -- there is no "cancel", since each toggle already is
+ * the final state. */
+static void refresh_layouts_picker_items(void)
+{
+    lv_obj_clean(s_settings_list);
+    char buf[80];
+    for (int i = 0; i < KB_LAYOUT_COUNT; i++) {
+        kb_layout_id_t id = (kb_layout_id_t)i;
+        snprintf(buf, sizeof(buf), "[%s] %s",
+                 kb_layout_is_active(id) ? "x" : " ",
+                 kb_layout_name(id));
+        lv_list_add_btn(s_settings_list, NULL, buf);
+    }
+    lv_list_add_btn(s_settings_list, NULL, "  Done (Esc)");
+    apply_list_selection_styles(s_settings_list, s_layouts_picker_sel);
+    s_layouts_picker_sel_prev = s_layouts_picker_sel;
+
+    sync_battery_labels();
+}
+
+static void update_layouts_picker_highlight(void)
+{
+    update_list_highlight(s_settings_list, s_layouts_picker_sel,
+                          s_layouts_picker_sel_prev);
+    s_layouts_picker_sel_prev = s_layouts_picker_sel;
+}
+
+static void close_layouts_picker(void)
+{
+    s_layouts_picker_open = false;
+    refresh_settings_items();
+}
+
 /* ---- Margin-change restart prompt ----
  * Renders into the same s_settings_list widget while
  * s_margin_confirm_open is true -- same reused-list pattern as the
@@ -3440,6 +3544,7 @@ static void show_settings(void)
 #if defined(CONFIG_DRAFTLING_DISPLAY_COLOR)
     s_theme_picker_open = false;
 #endif
+    s_layouts_picker_open = false;
     refresh_settings_items();
     sync_battery_labels();
 #if defined(CONFIG_DRAFTLING_DISPLAY_EPD)
@@ -3456,6 +3561,7 @@ static void close_settings(void)
 #if defined(CONFIG_DRAFTLING_DISPLAY_COLOR)
     s_theme_picker_open = false;
 #endif
+    s_layouts_picker_open = false;
     show_menu();
 }
 
@@ -3608,6 +3714,13 @@ static void settings_activate_item(int idx)
     } else if (idx == SETTINGS_IDX_MAXFILE) {
         /* Read-only display of the dynamically-sized editor buffer.
          * Enter is a no-op; the value is fixed at editor_init() time. */
+    } else if (idx == SETTINGS_IDX_LAYOUTS) {
+        /* Open the active-layouts checklist sub-list. Each row toggles
+         * immediately on Enter (applied + persisted on the spot); Esc
+         * returns to the settings list. */
+        s_layouts_picker_sel = 0;
+        s_layouts_picker_open = true;
+        refresh_layouts_picker_items();
 #if defined(CONFIG_DRAFTLING_DISPLAY_COLOR)
     } else if (idx == SETTINGS_IDX_THEME) {
         /* Open the theme picker sub-list. The user navigates with
@@ -3724,6 +3837,47 @@ static void handle_settings_key(const kb_event_t *ev)
         return;
     }
 #endif
+
+    if (s_layouts_picker_open) {
+        /* Total picker rows: KB_LAYOUT_COUNT checklist rows + 1 "Done" row. */
+        const int picker_count = KB_LAYOUT_COUNT + 1;
+        switch (ev->keycode) {
+        case KB_KEY_UP:
+            if (s_layouts_picker_sel > 0) s_layouts_picker_sel--;
+            update_layouts_picker_highlight();
+            break;
+        case KB_KEY_DOWN:
+            if (s_layouts_picker_sel < picker_count - 1) s_layouts_picker_sel++;
+            update_layouts_picker_highlight();
+            break;
+        case KB_KEY_ENTER:
+        case KB_KEY_SPACE:
+            /* Space is equivalent to Enter here so a row can be
+             * toggled without leaving the home row -- there is no
+             * text field on this screen for Space to type into. */
+            if (s_layouts_picker_sel >= 0 &&
+                s_layouts_picker_sel < KB_LAYOUT_COUNT) {
+                kb_layout_id_t id = (kb_layout_id_t)s_layouts_picker_sel;
+                /* kb_layout_set_active() silently refuses to remove the
+                 * last active layout, so the checklist can never be
+                 * emptied out from under the user. */
+                if (kb_layout_set_active(id, !kb_layout_is_active(id))) {
+                    save_active_layouts_to_nvs();
+                    refresh_layouts_picker_items();
+                }
+            } else {
+                /* Done row */
+                close_layouts_picker();
+            }
+            break;
+        case KB_KEY_ESCAPE:
+            close_layouts_picker();
+            break;
+        default:
+            break;
+        }
+        return;
+    }
 
     switch (ev->keycode) {
     case KB_KEY_UP:
@@ -4787,14 +4941,13 @@ static void handle_editor_key(const kb_event_t *ev)
 
     /* Ctrl shortcuts */
     if (ctrl) {
-        /* Interpret Ctrl shortcuts by physical key position (HID keycode),
-         * NOT by the current layout translation.  This ensures that
-         * Ctrl+S, Ctrl+L, etc. work regardless of the active layout.
-         * HID keycodes 0x04..0x1D map to a..z. */
-        char ch = 0;
-        if (ev->keycode >= 0x04 && ev->keycode <= 0x1D) {
-            ch = 'a' + (ev->keycode - 0x04);
-        }
+        /* kb_layout_shortcut_char() resolves the shortcut letter by the
+         * national layout for Latin layouts (so e.g. Ctrl+Z lands on
+         * the key printed Z on a German keyboard) and by the US
+         * physical key position for non-Latin layouts (Ukrainian,
+         * Hebrew, ...), which have no national Latin letter to remap
+         * to -- see kb_layout.h. */
+        char ch = kb_layout_shortcut_char(ev->keycode);
 
         /* Ctrl+1 / Ctrl+2 / Ctrl+3 control the split layout. HID
          * keycodes: 1 = 0x1E, 2 = 0x1F, 3 = 0x20. Handled by keycode
@@ -5348,12 +5501,11 @@ static void handle_browser_key(const kb_event_t *ev)
         return;
     }
 
-    /* Ctrl+G / Ctrl+W work from the file browser as well */
+    /* Ctrl+G / Ctrl+W work from the file browser as well. See the
+     * editor's Ctrl-shortcut block for why kb_layout_shortcut_char()
+     * is used instead of a raw layout translation. */
     if (ctrl) {
-        char ck = 0;
-        if (ev->keycode >= 0x04 && ev->keycode <= 0x1D) {
-            ck = 'a' + (ev->keycode - 0x04);
-        }
+        char ck = kb_layout_shortcut_char(ev->keycode);
         if (ck == 'g') {
             if (git_sync_is_configured() && wifi_manager_is_connected()) {
                 if (git_sync_start(GIT_SYNC_BOTH) == ESP_OK) {
@@ -5421,15 +5573,16 @@ static void handle_browser_key(const kb_event_t *ev)
 #endif
     }
 
-    /* Translate keycode to character for letter-key checks.
-     * ev->character is always 0 because ble_keyboard does not fill
-     * it -- all translation goes through kb_layout. */
-    const char *br_t = kb_layout_translate(ev->keycode, ev->modifier);
-    char ch = (br_t && br_t[0] && !br_t[1]) ? br_t[0] : 0;
+    /* Resolve the "N: New file" accelerator the same way Ctrl
+     * shortcuts are resolved (see kb_layout_shortcut_char()), not via
+     * a raw layout translation -- otherwise the N key would produce a
+     * non-Latin character under Ukrainian/Hebrew and this shortcut
+     * would silently stop working. */
+    char ch = kb_layout_shortcut_char(ev->keycode);
 
     uint32_t child_count = lv_obj_get_child_count(s_browser_list);
     if (child_count == 0) {
-        if (ch == 'n' || ch == 'N') {
+        if (ch == 'n') {
             editor_new_file();
             editor_ui_show_editor();
         }
@@ -5455,7 +5608,7 @@ static void handle_browser_key(const kb_event_t *ev)
         return;
     }
     default:
-        if (ch == 'n' || ch == 'N') {
+        if (ch == 'n') {
             editor_new_file();
             editor_ui_show_editor();
             return;
@@ -5504,9 +5657,8 @@ static void handle_inpane_browser_key(const kb_event_t *ev)
     }
 
     if (!ctrl) {
-        const char *t = kb_layout_translate(ev->keycode, ev->modifier);
-        char ch = (t && t[0] && !t[1]) ? t[0] : 0;
-        if (ch == 'n' || ch == 'N') {
+        char ch = kb_layout_shortcut_char(ev->keycode);
+        if (ch == 'n') {
             /* New untitled document in the focused pane (not a global
              * replace -- that is the single-pane behavior). */
             if (!open_into_pane(s_focus, NULL)) {
@@ -5802,6 +5954,7 @@ static void apply_pending_connect_state(void)
 #if defined(CONFIG_DRAFTLING_DISPLAY_COLOR)
         s_theme_picker_open = false;
 #endif
+        s_layouts_picker_open = false;
         s_save_open = false;
         if (s_save_panel) lv_obj_add_flag(s_save_panel, LV_OBJ_FLAG_HIDDEN);
         s_exit_open = false;
@@ -6815,6 +6968,7 @@ static void teardown_screens(void)
 #if defined(CONFIG_DRAFTLING_DISPLAY_COLOR)
     s_theme_picker_open       = false;
 #endif
+    s_layouts_picker_open     = false;
     s_factory_reset_confirm   = false;
     s_margins_changed         = false;
     s_margin_confirm_open     = false;
@@ -6893,6 +7047,7 @@ extern "C" void editor_ui_init(void)
     display_set_backlight(s_backlight_pct);
 #endif
     load_append_only_from_nvs();
+    load_active_layouts_from_nvs();
     load_margins_from_nvs();
     init_styles();
 

--- a/firmware/components/kb_layout/Kconfig.projbuild
+++ b/firmware/components/kb_layout/Kconfig.projbuild
@@ -14,19 +14,19 @@ config KB_LAYOUT_ENABLE_UA
 
 config KB_LAYOUT_ENABLE_DE
     bool "German (QWERTZ)"
-    default n
+    default y
     help
         Enable the German QWERTZ keyboard layout with umlauts.
 
 config KB_LAYOUT_ENABLE_FR
     bool "French (AZERTY)"
-    default n
+    default y
     help
         Enable the French AZERTY keyboard layout with accents.
 
 config KB_LAYOUT_ENABLE_HE
     bool "Hebrew (Israeli standard)"
-    default n
+    default y
     help
         Enable the Hebrew (Israeli standard SI 1452) keyboard layout.
         Enabling this option also pulls the Hebrew glyph range

--- a/firmware/components/kb_layout/include/kb_layout.h
+++ b/firmware/components/kb_layout/include/kb_layout.h
@@ -46,11 +46,60 @@ kb_layout_id_t kb_layout_get(void);
 /* Get the display name for a layout (e.g. "US", "UA", "DE", "FR") */
 const char *kb_layout_name(kb_layout_id_t layout);
 
-/* Cycle to the next layout and return its id */
+/* Cycle to the next active layout (see kb_layout_set_active()) and
+ * return its id. Layouts excluded from the active set are skipped. */
 kb_layout_id_t kb_layout_next(void);
 
 /* True when the active layout produces right-to-left script (Hebrew) */
 bool kb_layout_is_rtl(void);
+
+/* Resolves a HID keycode to the lowercase ASCII letter that Ctrl-combo
+ * keyboard shortcuts should match against, given the active layout:
+ *  - Latin layouts (US, DE, FR, ...) resolve to whichever letter that
+ *    physical key actually produces on the national layout's normal
+ *    (unshifted) layer -- not limited to the classic 26-key US letter
+ *    block, since a layout can move a Latin letter onto a key that is
+ *    a symbol on US. E.g. Ctrl+Z lands on the key printed Z on a
+ *    German (QWERTZ) keyboard, not the US Z position; French AZERTY
+ *    puts "m" on the semicolon key, so Ctrl+M on a French keyboard is
+ *    that key, not the US M position. A key that produces a
+ *    non-letter under this layout has no Ctrl-shortcut letter.
+ *  - Non-Latin layouts (Ukrainian, Hebrew, ...) fall back to the
+ *    classic 26-key US physical letter block (0x04..0x1D), since
+ *    there is no national Latin letter to remap the shortcut to --
+ *    Ctrl+N keeps working exactly as if the US layout were active.
+ * Returns 0 when the keycode has no shortcut letter under these rules. */
+char kb_layout_shortcut_char(uint8_t keycode);
+
+/* ------------------------------------------------------------------
+ * Active layout set -- the "Active language layouts" user setting.
+ *
+ * A layout must be compiled in (Kconfig) before it can be part of the
+ * active set. kb_layout_next() (Ctrl+L / Win+Space) only cycles through
+ * layouts in this set, so users who only need one or two layouts do
+ * not have to page through every compiled-in layout to get back to
+ * the one they want.
+ * ------------------------------------------------------------------ */
+
+/* True when a layout is in the active (rotated) set. */
+bool kb_layout_is_active(kb_layout_id_t layout);
+
+/* Number of layouts currently in the active set. Always >= 1. */
+int kb_layout_active_count(void);
+
+/* Add or remove a layout from the active set. Refuses to remove the
+ * last remaining active layout (returns false, no change) so the
+ * set is never empty. If the currently selected layout is removed,
+ * switches immediately to the next active layout. */
+bool kb_layout_set_active(kb_layout_id_t layout, bool active);
+
+/* Bitmask of the active set (bit N = layout id N), for persistence. */
+uint32_t kb_layout_get_active_mask(void);
+
+/* Restores an active-set bitmask (e.g. loaded from NVS). Bits for
+ * layouts that are not compiled in are ignored. If the result would
+ * be empty, falls back to the built-in default set. */
+void kb_layout_set_active_mask(uint32_t mask);
 
 #ifdef __cplusplus
 }

--- a/firmware/components/kb_layout/kb_layout.cpp
+++ b/firmware/components/kb_layout/kb_layout.cpp
@@ -19,6 +19,23 @@
 
 static kb_layout_id_t s_layout = (kb_layout_id_t)0;
 
+/* Default "Active language layouts" set: US and UA when compiled in,
+ * else the first compiled-in layout so the set is never empty. */
+static uint32_t default_active_mask(void)
+{
+    uint32_t mask = 0;
+#ifdef CONFIG_KB_LAYOUT_ENABLE_US
+    mask |= (1u << KB_LAYOUT_US);
+#endif
+#ifdef CONFIG_KB_LAYOUT_ENABLE_UA
+    mask |= (1u << KB_LAYOUT_UA);
+#endif
+    if (mask == 0) mask = 1u;
+    return mask;
+}
+
+static uint32_t s_active_mask = default_active_mask();
+
 /* HID keycodes for letter/number/symbol keys: 0x04..0x38 (53 keys) */
 #define KC_A     0x04
 #define KC_Z     0x1D
@@ -527,6 +544,29 @@ static const char *s_layout_names[KB_LAYOUT_COUNT] = {
 #endif
 };
 
+/* True for layouts whose normal (unshifted) layer produces plain Latin
+ * letters -- used by kb_layout_shortcut_char() below to decide whether
+ * Ctrl-shortcut letters should follow the national layout (Latin) or
+ * fall back to the US physical key position (non-Latin scripts, which
+ * have no national Latin letter to remap a shortcut to). */
+static const bool s_layout_is_latin[KB_LAYOUT_COUNT] = {
+#ifdef CONFIG_KB_LAYOUT_ENABLE_US
+    [KB_LAYOUT_US] = true,
+#endif
+#ifdef CONFIG_KB_LAYOUT_ENABLE_UA
+    [KB_LAYOUT_UA] = false,
+#endif
+#ifdef CONFIG_KB_LAYOUT_ENABLE_DE
+    [KB_LAYOUT_DE] = true,
+#endif
+#ifdef CONFIG_KB_LAYOUT_ENABLE_FR
+    [KB_LAYOUT_FR] = true,
+#endif
+#ifdef CONFIG_KB_LAYOUT_ENABLE_HE
+    [KB_LAYOUT_HE] = false,
+#endif
+};
+
 /* ------------------------------------------------------------------ */
 /* Public API                                                         */
 /* ------------------------------------------------------------------ */
@@ -550,8 +590,74 @@ extern "C" const char *kb_layout_name(kb_layout_id_t layout)
 
 extern "C" kb_layout_id_t kb_layout_next(void)
 {
-    s_layout = (kb_layout_id_t)((s_layout + 1) % KB_LAYOUT_COUNT);
+    kb_layout_id_t next = s_layout;
+    for (int i = 0; i < KB_LAYOUT_COUNT; i++) {
+        next = (kb_layout_id_t)((next + 1) % KB_LAYOUT_COUNT);
+        if (s_active_mask & (1u << next)) {
+            s_layout = next;
+            break;
+        }
+    }
     return s_layout;
+}
+
+extern "C" bool kb_layout_is_active(kb_layout_id_t layout)
+{
+    if (layout >= KB_LAYOUT_COUNT) return false;
+    return (s_active_mask & (1u << layout)) != 0;
+}
+
+extern "C" int kb_layout_active_count(void)
+{
+    int count = 0;
+    for (int i = 0; i < KB_LAYOUT_COUNT; i++) {
+        if (s_active_mask & (1u << i)) count++;
+    }
+    return count;
+}
+
+extern "C" bool kb_layout_set_active(kb_layout_id_t layout, bool active)
+{
+    if (layout >= KB_LAYOUT_COUNT) return false;
+    uint32_t bit = 1u << layout;
+
+    if (active) {
+        s_active_mask |= bit;
+        return true;
+    }
+
+    /* Refuse to drop the last active layout -- the set must never be
+     * empty, or Ctrl+L / Win+Space would have nothing to cycle to. */
+    if ((s_active_mask & ~bit) == 0) return false;
+
+    s_active_mask &= ~bit;
+    if (s_layout == layout) {
+        /* The currently selected layout just left the active set --
+         * switch to the next one immediately. */
+        kb_layout_next();
+    }
+    return true;
+}
+
+extern "C" uint32_t kb_layout_get_active_mask(void)
+{
+    return s_active_mask;
+}
+
+extern "C" void kb_layout_set_active_mask(uint32_t mask)
+{
+    mask &= (1u << KB_LAYOUT_COUNT) - 1;
+    if (mask == 0) mask = default_active_mask();
+    s_active_mask = mask;
+
+    if (!(s_active_mask & (1u << s_layout))) {
+        for (int i = 0; i < KB_LAYOUT_COUNT; i++) {
+            if (s_active_mask & (1u << i)) {
+                s_layout = (kb_layout_id_t)i;
+                break;
+            }
+        }
+    }
 }
 
 extern "C" bool kb_layout_is_rtl(void)
@@ -584,4 +690,35 @@ extern "C" const char *kb_layout_translate(uint8_t keycode, uint8_t modifier)
     }
 
     return result;
+}
+
+extern "C" char kb_layout_shortcut_char(uint8_t keycode)
+{
+    if (keycode < 0x04) return 0;
+
+    if (s_layout_is_latin[s_layout]) {
+        /* Latin layout: resolve to whichever letter this physical key
+         * actually produces on the national layout's normal
+         * (unshifted, no AltGr) layer. Deliberately NOT restricted to
+         * the classic 26-key US letter block (0x04..0x1D) -- a layout
+         * can move a Latin letter onto a key that is a symbol on US.
+         * French AZERTY, for example, puts "m" on the semicolon key
+         * (0x33) and a comma where US has "m", so Ctrl+M on a French
+         * keyboard is that semicolon-position key, not the US M
+         * position. A key producing a non-letter here (a genuine
+         * symbol under this layout) has no Ctrl-shortcut letter. */
+        const char *t = kb_layout_translate(keycode, 0);
+        if (t && !t[1]) {
+            if (t[0] >= 'a' && t[0] <= 'z') return t[0];
+            if (t[0] >= 'A' && t[0] <= 'Z') return (char)(t[0] - 'A' + 'a');
+        }
+        return 0;
+    }
+
+    /* Non-Latin layout (Ukrainian, Hebrew, ...): fall back to the
+     * classic 26-key US physical letter block, since there is no
+     * national Latin letter to remap a shortcut to (e.g. Ctrl+N keeps
+     * working exactly as if the US layout were active). */
+    if (keycode > 0x1D) return 0;
+    return (char)('a' + (keycode - 0x04));
 }

--- a/firmware/sdkconfig.defaults.sunton_8048s043
+++ b/firmware/sdkconfig.defaults.sunton_8048s043
@@ -12,6 +12,10 @@ CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
 CONFIG_DRAFTLING_TOUCHSCREEN=y
 
 # This author's keyboard is German; enable only US (QWERTY) and DE
-# (QWERTZ) layouts and drop the Ukrainian / French / Hebrew defaults.
+# (QWERTZ) layouts and drop the Ukrainian / French / Hebrew defaults
+# (all five are on by default in Kconfig, so UA/FR/HE need an
+# explicit override here to stay off for this board).
 CONFIG_KB_LAYOUT_ENABLE_UA=n
 CONFIG_KB_LAYOUT_ENABLE_DE=y
+CONFIG_KB_LAYOUT_ENABLE_FR=n
+CONFIG_KB_LAYOUT_ENABLE_HE=n


### PR DESCRIPTION
## Summary
- Add a new "Active language layouts" user setting (F1 -> Settings -> "Active layouts"): a checklist picker for which compiled-in keyboard layouts Ctrl+L / Win+Space rotate through, persisted in NVS, defaulting to US + UA. The title bar only shows the `[XX]` layout tag when more than one layout is active. Space toggles a row the same as Enter.
- All five keyboard layouts (US, UA, DE, FR, HE) now default to enabled in Kconfig; `sdkconfig.defaults.sunton_8048s043` explicitly disables FR/HE to preserve that board's original US+DE-only intent.
- Fix a bug where Ctrl-letter shortcuts (and the file browser's unmodified "N: New file" key) silently stopped working under non-Latin layouts (Ukrainian, Hebrew), because they matched against the layout-translated character instead of the physical key. The new `kb_layout_shortcut_char()` helper resolves shortcuts by the national layout for Latin layouts (e.g. Ctrl+M lands on the semicolon key under French AZERTY, where "m" lives) and by the US physical key position for non-Latin layouts.
- Add `CHANGELOG.md` to track user-facing changes since the `v1.0.1` first release.
- Update `AGENTS.md`'s `kb_layout` component writeup to document the new active-set and shortcut-resolution APIs.

## Test plan
- [x] `idf.py --preset xteink_x4_pro build` (monochrome e-paper, all 5 layouts enabled)
- [x] `idf.py --preset freenove_fnk0104a build` (color LCD, exercises the theme-picker + layouts-picker interaction)
- [x] Standalone host-side build of `kb_layout.cpp` verifying `kb_layout_shortcut_char()` for FR (semicolon->m, m-position->no shortcut), DE (Y/Z swap), UA/HE (US fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199ykLp5zv2sUkbHp4Uhxr5