### PR TITLE
Atomic writes to the MicroSD card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ in the git log.
   default in `idf.py menuconfig` (`DRAFTLING Keyboard Layouts`);
   previously only US and UA were on by default.
 
+### Changed
+
+- **Crash-safe file writes.** Saving a document (and its cursor/scroll
+  sidecar, and files written by Git sync) now writes to a temporary
+  file that is flushed to the MicroSD card and then renamed over the
+  target. A power loss or a card pulled out mid-save can no longer
+  truncate or corrupt the file being written -- the previous contents
+  stay intact until the complete new version is in place.
+
 ### Fixed
 
 - Ctrl-letter shortcuts (and the file browser's unmodified "N: New

--- a/firmware/components/sd_card/include/sd_card.h
+++ b/firmware/components/sd_card/include/sd_card.h
@@ -31,6 +31,9 @@ const char *sd_card_get_mount_point(void);
 
 /* Read entire file; caller must free(*out_buf) */
 esp_err_t sd_card_read_file(const char *path, char **out_buf, size_t *out_len);
+/* Overwrite a file atomically: the bytes are written to a temporary
+ * file and flushed to the card, then renamed over `path`. A crash or
+ * power loss mid-write leaves the previous contents of `path` intact. */
 esp_err_t sd_card_write_file(const char *path, const char *data, size_t len);
 esp_err_t sd_card_append_file(const char *path, const char *data, size_t len);
 bool sd_card_file_exists(const char *path);

--- a/firmware/components/sd_card/sd_card.cpp
+++ b/firmware/components/sd_card/sd_card.cpp
@@ -406,12 +406,57 @@ extern "C" esp_err_t sd_card_read_file(const char *path, char **out_buf, size_t 
 extern "C" esp_err_t sd_card_write_file(const char *path, const char *data, size_t len)
 {
     if (!s_card) return ESP_ERR_INVALID_STATE;
-    FILE *f = fopen(path, "wb");
-    if (!f) { ESP_LOGE(TAG, "Open for write failed: %s", path); return ESP_FAIL; }
+
+    /* Atomic write: stream the new contents into a temporary file next
+     * to the target, flush it all the way down to the card, then rename
+     * it over the target. A power loss or card yank while the bytes are
+     * being written therefore never truncates or half-overwrites
+     * `path` -- the incomplete data only ever lands in the temporary
+     * file, which is removed on the next write. FAT's rename() cannot
+     * replace an existing file, so the old file is unlinked immediately
+     * before the rename; the only unguarded window is that single
+     * directory-entry swap, and the fully written replacement still
+     * exists as the temporary file if power is lost inside it.
+     *
+     * The temporary lives in the same directory as `path` (rename must
+     * stay within one filesystem) and is named ".<basename>.dtmp" so a
+     * leftover after a crash is hidden from the file browser, which
+     * skips dot-prefixed entries. */
+    char tmp[512];
+    const char *slash = strrchr(path, '/');
+    int n;
+    if (slash) {
+        n = snprintf(tmp, sizeof(tmp), "%.*s/.%s.dtmp",
+                     (int)(slash - path), path, slash + 1);
+    } else {
+        n = snprintf(tmp, sizeof(tmp), ".%s.dtmp", path);
+    }
+    if (n <= 0 || (size_t)n >= sizeof(tmp)) {
+        ESP_LOGE(TAG, "Path too long for atomic write: %s", path);
+        return ESP_FAIL;
+    }
+
+    FILE *f = fopen(tmp, "wb");
+    if (!f) { ESP_LOGE(TAG, "Open for write failed: %s", tmp); return ESP_FAIL; }
     size_t wr = fwrite(data, 1, len, f);
-    fsync(fileno(f));
-    fclose(f);
-    return (wr == len) ? ESP_OK : ESP_FAIL;
+    bool ok = (wr == len);
+    if (fflush(f) != 0) ok = false;
+    if (ok && fsync(fileno(f)) != 0) ok = false;
+    if (fclose(f) != 0) ok = false;
+    if (!ok) {
+        ESP_LOGE(TAG, "Write failed: %s (%zu/%zu bytes)", tmp, wr, len);
+        remove(tmp);
+        return ESP_FAIL;
+    }
+
+    remove(path);
+    if (rename(tmp, path) != 0) {
+        /* Leave the temporary file in place: it holds the only complete
+         * copy of the new contents now that the old file is gone. */
+        ESP_LOGE(TAG, "Rename %s -> %s failed: %s", tmp, path, strerror(errno));
+        return ESP_FAIL;
+    }
+    return ESP_OK;
 }
 
 extern "C" esp_err_t sd_card_append_file(const char *path, const char *data, size_t len)


### PR DESCRIPTION
## What

Make `sd_card_write_file()` crash-safe: instead of opening the target
file with `"wb"` (which truncates it immediately), the new contents are
written to a temporary file, flushed all the way down to the card, and
then renamed over the target.

A power loss or a card yanked out mid-write can no longer leave a
truncated or half-overwritten file. The previous contents stay intact
until the complete new version is in place.

## Scope

Everything that persists data to the SD card goes through
`sd_card_write_file()`, so this one change covers:

- document saves (`editor_save_file` / `editor_save_file_as`)
- the editor's cursor/scroll sidecar (`editor_save_meta`)
- blob checkout during Git sync (`git_sync.cpp`)

`git_sync`'s loose object store (`git_odb.c`) already used the same
temp-file + `rename()` pattern; this brings the shared helper in line
with it.

## Details

- The temporary file lives in the same directory as the target (a
  `rename()` has to stay on one filesystem) and is named
  `.<basename>.dtmp`. The leading dot hides a post-crash leftover from
  the file browser, which skips dot-prefixed entries.
- FatFs `rename()` cannot replace an existing file, so the old file is
  `remove()`d immediately before the rename. If power is lost in that
  small window, the fully written replacement is still on the card as
  the `.dtmp` sibling.
- Write errors (`fwrite` short count, `fflush`/`fsync`/`fclose`
  failure) now propagate instead of being swallowed; the temp file is
  cleaned up on failure.

## Testing

- `idf.py build` for `xteink_x4_pro` passes.
- Not yet exercised on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
