### PR TITLE
Xteink X4 Pro: OTA partition table so stock/Crosspoint can be reinstalled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,13 @@ this document).
 ```
 CMakeLists.txt              Top-level CMake project file
 CMakePresets.json           Per-board build presets (idf.py --preset <board>)
-partitions.csv              Custom partition table (16 MB flash)
+partitions.csv              Custom partition table (16 MB flash, single
+                            "factory" app) -- used by every board except
+                            the two below
+partitions_8mb.csv          8 MB-flash variant (Elecrow CrowPanel 5.79")
+partitions_xteink_x4_pro.csv Dual-OTA layout (otadata + ota_0/ota_1) so
+                            the Xteink X4 Pro can be re-flashed with the
+                            stock or Crosspoint firmware afterwards
 sdkconfig.defaults          Common Kconfig defaults for all targets
 sdkconfig.defaults.esp32s3  ESP32-S3-specific defaults (PSRAM, BLE, WiFi)
 sdkconfig.defaults.<board>  Per-board target + hardware-model defaults, one
@@ -1264,6 +1270,14 @@ tree referenced in steps 1-4.
    gh release upload vX.Y.Z draftling-<board>-bootloader.bin \
        draftling-<board>-partition-table.bin draftling-<board>.bin
    ```
+   `xteink_x4_pro` also needs a fourth image,
+   `draftling-xteink_x4_pro-otadata.bin` (from
+   `firmware/build/xteink_x4_pro/ota_data_initial.bin`): its partition
+   table is dual-OTA (`partitions_xteink_x4_pro.csv`), so a clean flash
+   must also (re)initialise the `otadata` partition at `0xd000` -- an
+   8 KB all-`0xFF` blob that makes the bootloader pick `ota_0`.
+   Otherwise a stale `otadata` left by the stock firmware could point
+   the bootloader at the empty `ota_1`.
 5. Update the web flasher on the `_flasher` branch (see its own
    `README.md` for the full layout and rationale -- it is an orphan
    branch with no shared history with `main`, published via GitHub
@@ -1271,13 +1285,17 @@ tree referenced in steps 1-4.
    switching your main checkout to it):
    - Add `firmware/vX.Y.Z/` (on `_flasher`) with the same binaries
      uploaded to the release, named identically, for each board
-     included in this release.
+     included in this release (including
+     `draftling-xteink_x4_pro-otadata.bin` for the X4 Pro).
    - In `manifest.json`, each board has its own `releases` array
      (newest first). For each board this release covers, prepend a new
      entry with its `tag`, flash mode/freq/size, and `parts[].path`
      pointing at `firmware/vX.Y.Z/...`. Leave other boards' `releases`
      untouched -- they keep pointing at whatever tag they last shipped
-     under.
+     under. `xteink_x4_pro` has a fourth `parts` entry:
+     `{ "path": "firmware/vX.Y.Z/draftling-xteink_x4_pro-otadata.bin",
+     "offset": "0xd000" }` (its `draftling-xteink_x4_pro.bin` app part
+     still sits at `0x10000`).
    - Commit and push to `_flasher` -- GitHub Pages redeploys
      automatically; no separate deploy step.
    - A `firmware/<tag>/` directory (on `_flasher`) can be deleted once

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ in the git log.
 
 ### Fixed
 
+- **Xteink X4 Pro**: the flashed partition table now keeps an `otadata`
+  partition and a dual-OTA app layout (`ota_0` / `ota_1`), instead of a
+  single `factory` partition. The stock Xteink firmware and the
+  third-party Crosspoint firmware are installed by OTA updaters that
+  abort with "Partition table has no otadata partition" against the old
+  layout; with this change the device can be returned to stock or moved
+  to Crosspoint without re-flashing a partition table over USB first.
+  (Re-flashing Draftling on an X4 Pro that already runs it clears the
+  BLE keyboard pairings once, because the NVS partition is resized.)
 - Ctrl-letter shortcuts (and the file browser's unmodified "N: New
   file" key) no longer silently stop working when a non-Latin layout
   (Ukrainian, Hebrew) is active -- they now resolve to the same US

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -286,6 +286,31 @@ has since been dialed in against a physical unit with
 of where the finger was; `TOUCH_MIRROR_X`/`TOUCH_MIRROR_Y` are now 1/0
 (swapped from the initial 0/1) to correct it.
 
+### Partition table
+
+Unlike every other board (which uses the shared single-`factory`
+`firmware/partitions.csv`), the X4 Pro is flashed with a dedicated
+`firmware/partitions_xteink_x4_pro.csv` -- a standard ESP-IDF dual-OTA
+layout: `nvs` (16 KB), `otadata`, `phy_init`, and two 8.1 MB app slots
+`ota_0` / `ota_1`. Draftling runs from `ota_0` (still at flash offset
+`0x10000`, so the web-flasher offsets are unchanged); `ota_1` is left
+empty.
+
+The reason is recovery: the stock Xteink firmware and the third-party
+**Crosspoint** firmware are both installed by OTA-style updaters that
+refuse to run against a partition table with no `otadata` partition
+("Partition table has no otadata partition"). The old single-`factory`
+table left an X4 Pro that had been flashed with Draftling unable to
+accept either without first re-flashing a partition table over USB.
+Keeping an OTA layout means the stock / Crosspoint updater finds
+`otadata` plus a free 8.1 MB slot and can write itself in.
+
+There is no `nvs_keys` partition (only used with NVS encryption, which
+Draftling does not enable). `nvs` shrinks from 24 KB to 16 KB (the
+ESP-IDF two-OTA default) to make room for `otadata` + `phy_init` below
+the 64 KB-aligned `ota_0` offset; re-flashing Draftling onto an X4 Pro
+that already runs it therefore clears the stored BLE pairings once.
+
 ## Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI Display
 
 [Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI

--- a/firmware/partitions_xteink_x4_pro.csv
+++ b/firmware/partitions_xteink_x4_pro.csv
@@ -1,0 +1,31 @@
+# Xteink X4 Pro -- partition table
+#
+# Every other board uses a single "factory" app partition
+# (partitions.csv / partitions_8mb.csv). The Xteink X4 Pro instead uses
+# the standard ESP-IDF dual-OTA layout: an "otadata" partition plus two
+# app slots (ota_0 / ota_1). Draftling runs from ota_0; ota_1 is left
+# empty.
+#
+# Why this board is different: the X4 Pro ships from the factory with an
+# OTA-capable partition table, and both the stock Xteink firmware and
+# the third-party "Crosspoint" firmware are installed by OTA updaters
+# that abort against a table with no "otadata" partition, with the error
+# "Partition table has no otadata partition". Keeping an OTA layout here
+# means the device can be returned to stock, or moved to Crosspoint,
+# without having to re-flash a partition table over USB first. It also
+# leaves room for a future Draftling build to ship its own OTA update.
+#
+# The app slots (0x7F0000 = ~8.1 MB each) are far larger than Draftling
+# needs (~2.3 MB), so a stock or Crosspoint image fits in either slot
+# too. "nvs" is 0x4000 (16 KB -- the ESP-IDF two-OTA default) so that
+# "otadata" and "phy_init" still fit below the 64 KB-aligned ota_0
+# offset; the BLE bonds and the handful of Draftling settings keys fit
+# comfortably in that. There is no "nvs_keys" partition (it is only used
+# with NVS encryption, which Draftling does not enable).
+#
+# Name,   Type, SubType,  Offset,    Size,      Flags
+nvs,      data, nvs,      0x9000,    0x4000,
+otadata,  data, ota,      0xd000,    0x2000,
+phy_init, data, phy,      0xf000,    0x1000,
+ota_0,    app,  ota_0,    0x10000,   0x7F0000,
+ota_1,    app,  ota_1,    0x800000,  0x7F0000,

--- a/firmware/sdkconfig.defaults.xteink_x4_pro
+++ b/firmware/sdkconfig.defaults.xteink_x4_pro
@@ -3,3 +3,12 @@
 
 CONFIG_IDF_TARGET="esp32s3"
 CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO=y
+
+# Use a dual-OTA partition table (with an "otadata" partition) instead
+# of the shared single-"factory" partitions.csv. The stock Xteink
+# firmware and the third-party Crosspoint firmware are installed by OTA
+# updaters that refuse to run without an "otadata" partition ("Partition
+# table has no otadata partition"); keeping an OTA layout lets the
+# device be returned to stock or moved to Crosspoint without first
+# re-flashing a partition table over USB. See partitions_xteink_x4_pro.csv.
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_xteink_x4_pro.csv"


### PR DESCRIPTION
## Problem

After flashing Draftling, an Xteink X4 Pro can no longer be returned to
the **stock Xteink firmware** or moved to **Crosspoint**. Both are
installed by OTA-style updaters that abort with:

> Partition table has no otadata partition

Draftling's shared `partitions.csv` is a single `factory` app partition
with no `otadata` and no OTA slots, so there is nothing for those
updaters to write into and no OTA-data partition for them to look at.

## Fix

Give the X4 Pro its own `firmware/partitions_xteink_x4_pro.csv` -- the
standard ESP-IDF **dual-OTA** layout, selected via
`CONFIG_PARTITION_TABLE_CUSTOM_FILENAME` in
`sdkconfig.defaults.xteink_x4_pro`:

| Partition | Type       | Offset     | Size    |
|-----------|------------|------------|---------|
| `nvs`     | data/nvs   | `0x9000`   | 16 KB   |
| `otadata` | data/ota   | `0xd000`   | 8 KB    |
| `phy_init`| data/phy   | `0xf000`   | 4 KB    |
| `ota_0`   | app/ota_0  | `0x10000`  | 8128 KB |
| `ota_1`   | app/ota_1  | `0x800000` | 8128 KB |

- Draftling runs from `ota_0` -- still at flash offset `0x10000`, so
  the bootloader / partition-table / app offsets used by the web
  flasher are unchanged.
- `ota_1` is left empty; a stock or Crosspoint OTA writes itself there
  (either image fits comfortably in 8 MB), flips `otadata`, and boots.
- `nvs` shrinks 24 KB -> 16 KB (the ESP-IDF two-OTA default) to fit
  `otadata` + `phy_init` below the 64 KB-aligned `ota_0` offset.
  **Consequence:** re-flashing Draftling onto an X4 Pro that already
  runs it clears the stored BLE keyboard pairings once. (stock ->
  Draftling is unaffected -- that path wipes NVS anyway.)
- No `nvs_keys` partition -- it is only used with NVS encryption, which
  Draftling does not enable.

A clean flash of this board now also writes `ota_data_initial.bin`
(8 KB of `0xFF`) at `0xd000` so the bootloader deterministically
selects `ota_0` even if a stale `otadata` from the stock firmware is
still on the chip. `idf.py flash` does this automatically; AGENTS.md's
release + web-flasher steps are updated to ship the extra
`draftling-xteink_x4_pro-otadata.bin` and add the 4th manifest part.

## Docs

- `HARDWARE.md` -- new "Partition table" subsection under Xteink X4 Pro
- `CHANGELOG.md`, `AGENTS.md` (file tree + release process)

## Testing

- `idf.py --preset xteink_x4_pro build` passes; generated partition
  table verified with `gen_esp32part.py` (otadata + ota_0/ota_1
  present).
- `idf.py --preset elecrow_crowpanel_579 build` still passes (shared
  config untouched).
- Not exercised on hardware; the actual stock/Crosspoint reinstall
  path can only be confirmed on a real X4 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
