### PR TITLE
Portrait display orientation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1061,8 +1061,15 @@ ESP32-S3-only (`depends on IDF_TARGET_ESP32S3`):
   a short press (there is no hardware power-off latch on this board)
   or forgets BLE keyboards on a 2 s hold. The enclosure's cover
   overlaps the panel; the user-adjustable screen margins (see below)
-  compensate. Tested on physical hardware after an initial blind
-  port; see HARDWARE.md. *Requires ESP32-S3.*
+  compensate. `app_main()` power-cycles the GT911 (via its active-low
+  `TOUCH_POWER_EN_PIN`) very early, *before* the shared I2C bus is
+  created, and calls `gpio_deep_sleep_hold_dis()` first: a warm reboot
+  (`esp_restart()` from the Settings "restart to apply" prompt, a panic,
+  a watchdog) does not reset the I2C peripheral or the GT911, so
+  without the power-cycle the controller comes up wedged on the bus and
+  touch is dead until the next deep-sleep cycle. Tested on physical
+  hardware after an initial blind port; see HARDWARE.md.
+  *Requires ESP32-S3.*
 - **DRAFTLING_MODEL_ELECROW_CROWPANEL_579** -- Elecrow CrowPanel
   ESP32-S3 5.79" E-Paper HMI Display: 792x272 black/white e-paper
   panel built from two SSD1683 controllers over plain SPI, driven by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,7 +443,10 @@ and relabelled rows). "Sleep without saving" calls
 document from the SD card and clears every modified untitled one -- so
 the pre-sleep auto-save then has nothing to persist. From the F1 menu
 the item first `close_menu()`s so the overlay is drawn on the editor
-screen it belongs to.
+screen it belongs to. `Ctrl+P` also works from the full-screen file
+browser (`handle_browser_key()`); there it just calls
+`standby_enter_sleep()` (no editor screen to prompt on -- the pre-sleep
+auto-save covers any open document).
 
 The editor UI supports a two-pane **split screen** built
 on the multi-document engine. `editor_ui.cpp` wraps the per-pane UI
@@ -468,7 +471,12 @@ the 1 px rule between them. Shortcuts: `Ctrl+1` single pane
 first-pane-2/3 then toggling to 1/3 (`editor_ui_cycle_wide_split()`),
 `Ctrl+Tab` move focus between panes (`editor_ui_focus_other_pane()`). Digit HID keycodes (1 = 0x1E,
 2 = 0x1F, 3 = 0x20) and `KB_KEY_TAB` are matched before the a..z Ctrl
-switch in `handle_editor_key()`. While split, the file browser
+switch in `handle_editor_key()`. `Ctrl+1/2/3` also work from the
+full-screen file browser (`handle_browser_key()`): the panes live on
+the editor screen, so there it only updates `s_split_mode` + NVS and
+the new layout shows on the next file open. The in-pane (split-mode)
+selector swallows `Ctrl+1/2/3` -- changing the split would pull the rug
+out from under the overlay. While split, the file browser
 (`Ctrl+O`) targets the focused pane via `open_into_pane()`, so each
 panel opens a file for itself (focus a pane, then `Ctrl+O`); opening
 the same path in both panes shares one refcounted buffer (two views of
@@ -1117,13 +1125,16 @@ by `display_orientation_init()` which `main.cpp` calls right after
 "Display orientation" row. NVS namespace `disporient`, key `portrait`
 (u8). Landscape on a fresh install.
 
-Portrait adds another 90 degrees to the board's build-time base
-rotation: `app_config.h`'s `DISPLAY_ROTATE_EFFECTIVE` is
-`DISPLAY_ROTATE + 90` (mod 360) in portrait, and that is what
-`main.cpp` passes to `draftling_lvgl_port_init()`. LVGL then swaps its
-own reported resolution, and `flush_cb` software-rotates each tile back
-to physical panel coordinates -- the display backends stay
-rotation-agnostic. `DISPLAY_LOGICAL_WIDTH/HEIGHT` and the touchscreen
+Portrait adds a quarter turn to the board's build-time base rotation:
+`app_config.h`'s `DISPLAY_ROTATE_EFFECTIVE` is `DISPLAY_ROTATE +
+CONFIG_DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE` (mod 360) in portrait,
+and that is what `main.cpp` passes to `draftling_lvgl_port_init()`.
+`DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE` is a non-prompted derived
+`int` (Kconfig.projbuild) defaulting to **90**; the **Xteink X4 Pro**
+sets it to **270** because that board's enclosure reads better with
+portrait turned the opposite way. LVGL then swaps its own reported
+resolution, and `flush_cb` software-rotates each tile back to physical
+panel coordinates -- the display backends stay rotation-agnostic. `DISPLAY_LOGICAL_WIDTH/HEIGHT` and the touchscreen
 `logical_width/height` stay in the pre-rotation (panel-native) frame,
 exactly as for the `DISPLAY_ROTATE=90/270` boards; LVGL applies the
 rotation to indev points itself (`user_rotate_deg` stays 0).
@@ -1196,9 +1207,12 @@ exposed as the hidden `int` symbol **DRAFTLING_DISPLAY_ROTATE_ANGLE**,
 consumed in `app_config.h` as `DISPLAY_ROTATE`.
 
 The runtime **"Display orientation"** setting (F1 -> Settings; see the
-"Display orientation" section below) adds another 90 degrees on top of
-this for portrait -- `app_config.h`'s `DISPLAY_ROTATE_EFFECTIVE` is
-what `main.cpp` actually passes to `draftling_lvgl_port_init()`.
+"Display orientation" section below) adds
+`DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE` degrees on top of this for
+portrait -- a second non-prompted derived `int` in this file, default
+90, set to 270 on the Xteink X4 Pro. `app_config.h`'s
+`DISPLAY_ROTATE_EFFECTIVE` is what `main.cpp` actually passes to
+`draftling_lvgl_port_init()`.
 
 #### High-density font selection (DRAFTLING_DISPLAY_HIDPI)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,10 @@ Per-board display backends behind a single C API:
   reliably complete it (matching what pressing Ctrl+R always did) --
   see HARDWARE.md's CrowPanel section and PR #47 for the full
   investigation.
+- **display_margins.cpp** / **display_orientation.cpp** -- the two
+  runtime, NVS-persisted, frozen-at-boot display settings that feed
+  `SCR_W`/`SCR_H` and the LVGL rotation angle. See the "Screen margins"
+  and "Display orientation" sections further down.
 
 The component's `idf_component.yml` declares the `vroland/epdiy`
 dependency required by both e-paper backends; the source files
@@ -379,12 +383,15 @@ size, **Backlight** (NN%, only on boards with
 `CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT` -- the value is persisted
 in NVS under the `editor` namespace and applied at boot via
 `display_set_backlight()`; default 50%), color theme (only on
-`CONFIG_DRAFTLING_DISPLAY_COLOR`), append-only editing, four screen
-margins (Left/Right/Top/Bottom, 0-40 px in 2 px steps, zero by
-default -- see the "Screen margins" section above; each change is
-persisted immediately but only takes effect after a restart, hence
-the "(restart to apply)" suffix on their labels), factory reset and
-back. ("Sleep now" used to sit here; it is now a top-level F1 menu item
+`CONFIG_DRAFTLING_DISPLAY_COLOR`), append-only editing, **display
+orientation** (Landscape / Portrait -- see the "Display orientation"
+section below), four screen margins (Left/Right/Top/Bottom, 0-40 px in
+2 px steps, zero by default -- see the "Screen margins" section above),
+factory reset and back. The orientation and margin rows are persisted
+immediately but only take effect after a restart, hence the "(restart
+to apply)" suffix on their labels; leaving Settings with any of them
+changed this visit (`s_restart_needed`) raises the shared "Restart now
+to apply changes" prompt. ("Sleep now" used to sit here; it is now a top-level F1 menu item
 -- see below.) Picking a new color theme does NOT reboot the device:
 `rebuild_screens_for_theme()` deletes every screen / overlay /
 screen-bound timer, re-runs `init_styles()` under the new palette,
@@ -438,7 +445,7 @@ the pre-sleep auto-save then has nothing to persist. From the F1 menu
 the item first `close_menu()`s so the overlay is drawn on the editor
 screen it belongs to.
 
-The editor UI supports a vertical (left/right) **split screen** built
+The editor UI supports a two-pane **split screen** built
 on the multi-document engine. `editor_ui.cpp` wraps the per-pane UI
 state (container, cursor, logo, line-label / selection-rect arrays,
 render caches, bound `editor_doc_t`, and pane geometry x / w / y / h)
@@ -452,12 +459,14 @@ handling a key. `editor_ui_refresh()` loops the active panes
 (unfocused first, focused last) calling `refresh_active_pane()` for
 each, then updates the title / battery once. The split layout is
 driven by `split_mode_t` (SPLIT_NONE, SPLIT_HALF, SPLIT_LEFT_2_3,
-SPLIT_LEFT_1_3); `recalc_pane_geometry()` keeps both panes full-height
-and only varies x / width (1 px divider via `s_pane_divider`).
-Shortcuts: `Ctrl+1` single pane (`SPLIT_NONE`), `Ctrl+2` equal split
-(`SPLIT_HALF`), `Ctrl+3` left-2/3 then toggling to left-1/3
-(`editor_ui_cycle_wide_split()`), `Ctrl+Tab` move focus between panes
-(`editor_ui_focus_other_pane()`). Digit HID keycodes (1 = 0x1E,
+SPLIT_LEFT_1_3 -- read "LEFT" as "first pane"); `recalc_pane_geometry()`
+splits along the display's long axis: left/right (vary x / width, full
+height) in landscape, top/bottom (vary y / height, full width) in
+portrait (`display_orientation_is_portrait()`), with `s_pane_divider`
+the 1 px rule between them. Shortcuts: `Ctrl+1` single pane
+(`SPLIT_NONE`), `Ctrl+2` equal split (`SPLIT_HALF`), `Ctrl+3`
+first-pane-2/3 then toggling to 1/3 (`editor_ui_cycle_wide_split()`),
+`Ctrl+Tab` move focus between panes (`editor_ui_focus_other_pane()`). Digit HID keycodes (1 = 0x1E,
 2 = 0x1F, 3 = 0x20) and `KB_KEY_TAB` are matched before the a..z Ctrl
 switch in `handle_editor_key()`. While split, the file browser
 (`Ctrl+O`) targets the focused pane via `open_into_pane()`, so each
@@ -1096,6 +1105,39 @@ new board with a different resolution, add a model `config` block
 inside the `DRAFTLING_HARDWARE_MODEL` choice and extend the
 per-model `default` lines on these symbols.
 
+### Display orientation (user-adjustable, not a Kconfig setting)
+
+Landscape (default) or portrait, a **runtime, NVS-persisted** setting
+modelled exactly on the screen margins above:
+`components/display/display_orientation.{h,cpp}` expose
+`display_orientation_is_portrait()` (frozen, session-lifetime, loaded
+by `display_orientation_init()` which `main.cpp` calls right after
+`display_margins_init()`), plus `display_orientation_set_portrait()` /
+`display_orientation_get_pending_portrait()` for the F1 -> Settings
+"Display orientation" row. NVS namespace `disporient`, key `portrait`
+(u8). Landscape on a fresh install.
+
+Portrait adds another 90 degrees to the board's build-time base
+rotation: `app_config.h`'s `DISPLAY_ROTATE_EFFECTIVE` is
+`DISPLAY_ROTATE + 90` (mod 360) in portrait, and that is what
+`main.cpp` passes to `draftling_lvgl_port_init()`. LVGL then swaps its
+own reported resolution, and `flush_cb` software-rotates each tile back
+to physical panel coordinates -- the display backends stay
+rotation-agnostic. `DISPLAY_LOGICAL_WIDTH/HEIGHT` and the touchscreen
+`logical_width/height` stay in the pre-rotation (panel-native) frame,
+exactly as for the `DISPLAY_ROTATE=90/270` boards; LVGL applies the
+rotation to indev points itself (`user_rotate_deg` stays 0).
+
+In `editor_ui.cpp`, `scr_axes_swapped()` folds the build base and the
+portrait flag into one XOR that decides whether `SCR_W`/`SCR_H` use the
+panel width or height. `recalc_pane_geometry()` / `layout_panes()`
+split top/bottom instead of left/right when portrait (the split always
+follows the display's long axis). Frozen for the session for the same
+reason as the margins -- the LVGL canvas and widget tree are built once
+at boot -- so a change only applies after a restart, offered by
+`request_close_settings()` (shared with the margin-change prompt via
+`s_restart_needed` / the "Restart now to apply changes" list).
+
 #### E-paper full-refresh interval (DRAFTLING_EPD_FULL_REFRESH_INTERVAL)
 
 `int` used by e-paper backends only (gated on
@@ -1146,10 +1188,17 @@ init branch in `main/main.cpp`.
 
 #### Display Rotation (DRAFTLING_DISPLAY_ROTATE)
 
-A `choice` that sets the display rotation angle. Options are 0, 90, 180,
-and 270 degrees. The default is 0 (no rotation). The selected angle is
+A `choice` that sets the **build-time base** display rotation angle.
+Options are 0, 90, 180, and 270 degrees. The default is 0 (no
+rotation); the natively-portrait Freenove panels default to 90 and the
+Tab5 to 270 so the editor renders landscape. The selected angle is
 exposed as the hidden `int` symbol **DRAFTLING_DISPLAY_ROTATE_ANGLE**,
 consumed in `app_config.h` as `DISPLAY_ROTATE`.
+
+The runtime **"Display orientation"** setting (F1 -> Settings; see the
+"Display orientation" section below) adds another 90 degrees on top of
+this for portrait -- `app_config.h`'s `DISPLAY_ROTATE_EFFECTIVE` is
+what `main.cpp` actually passes to `draftling_lvgl_port_init()`.
 
 #### High-density font selection (DRAFTLING_DISPLAY_HIDPI)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,14 @@ Per-board display backends behind a single C API:
   RGB565 output to the backend's 1-bpp pixel format via
   `display_set_pixel()`, and runs the LVGL tick/task timer. Thread
   safety is provided by a mutex exposed as `lvgl_port_lock()` /
-  `lvgl_port_unlock()`.
+  `lvgl_port_unlock()`. `flush_cb` software-rotates each tile
+  (`rotate_tile_rgb565()` + `map_area_to_physical()`) for a 90/180/270
+  rotation -- the backends only ever see physical panel coordinates.
+  Its rotation sense is the mirror of LVGL's own
+  `lv_display_rotate_area/point()`, so `lv_display_set_rotation()` is
+  fed the mirrored quarter turn via `lvgl_rotation_for_port_deg()` --
+  see the "Display orientation" section for why that keeps touch input
+  aligned.
 - **display_rgb.cpp** -- parallel RGB565 backend for the ESP32-S3 LCD
   RGB peripheral (`esp_lcd_new_rgb_panel`), selected by
   `CONFIG_DRAFTLING_DISPLAY_RGB`. Shared by the Sunton ESP32-8048S070C
@@ -471,12 +478,16 @@ the 1 px rule between them. Shortcuts: `Ctrl+1` single pane
 first-pane-2/3 then toggling to 1/3 (`editor_ui_cycle_wide_split()`),
 `Ctrl+Tab` move focus between panes (`editor_ui_focus_other_pane()`). Digit HID keycodes (1 = 0x1E,
 2 = 0x1F, 3 = 0x20) and `KB_KEY_TAB` are matched before the a..z Ctrl
-switch in `handle_editor_key()`. `Ctrl+1/2/3` also work from the
-full-screen file browser (`handle_browser_key()`): the panes live on
-the editor screen, so there it only updates `s_split_mode` + NVS and
-the new layout shows on the next file open. The in-pane (split-mode)
-selector swallows `Ctrl+1/2/3` -- changing the split would pull the rug
-out from under the overlay. While split, the file browser
+switch in `handle_editor_key()`. `Ctrl+1/2/3` also work from both file
+browsers: `handle_browser_key()` (full-screen) applies the mode and, if
+that enables a split, switches straight to the editor so the layout is
+visible immediately (`Ctrl+O` in a pane then picks its file);
+`handle_inpane_browser_key()` (the split-mode overlay) closes the
+overlay and re-applies the mode via `editor_ui_apply_split_mode()`,
+which repaints and hands key routing back to `handle_editor_key()` --
+`Ctrl+1` from there is how the user collapses a split entered by
+mistake (a split editor shows this overlay, not the full-screen
+browser, on Esc). While split, the file browser
 (`Ctrl+O`) targets the focused pane via `open_into_pane()`, so each
 panel opens a file for itself (focus a pane, then `Ctrl+O`); opening
 the same path in both panes shares one refcounted buffer (two views of
@@ -1134,10 +1145,23 @@ and that is what `main.cpp` passes to `draftling_lvgl_port_init()`.
 sets it to **270** because that board's enclosure reads better with
 portrait turned the opposite way. LVGL then swaps its own reported
 resolution, and `flush_cb` software-rotates each tile back to physical
-panel coordinates -- the display backends stay rotation-agnostic. `DISPLAY_LOGICAL_WIDTH/HEIGHT` and the touchscreen
-`logical_width/height` stay in the pre-rotation (panel-native) frame,
-exactly as for the `DISPLAY_ROTATE=90/270` boards; LVGL applies the
-rotation to indev points itself (`user_rotate_deg` stays 0).
+panel coordinates -- the display backends stay rotation-agnostic.
+`DISPLAY_LOGICAL_WIDTH/HEIGHT` and the touchscreen `logical_width/height`
+stay in the pre-rotation (panel-native) frame; the touchscreen
+component's `user_rotate_deg` stays 0 and LVGL rotates each incoming
+indev point itself (`lv_display_rotate_point()` in
+`indev_pointer_proc()`).
+
+The subtlety: `flush_cb` in `lvgl_port.cpp` software-rotates pixels
+with a rotation sense OPPOSITE to LVGL's own
+`lv_display_rotate_area()` / `lv_display_rotate_point()`. So
+`lv_display_set_rotation()` is fed the **mirrored** quarter turn --
+`lvgl_rotation_for_port_deg()` maps 90<->270 (0 and 180 unchanged).
+That keeps the reported-resolution swap the same (90 and 270 both swap)
+while making `lv_display_rotate_point()`'s physical->logical map the
+exact inverse of `flush_cb`'s logical->physical pixel map, so a tap
+lands under the finger in every orientation. (Before this, a 90/270
+base-rotation or portrait mode put touch input a quarter turn off.)
 
 In `editor_ui.cpp`, `scr_axes_swapped()` folds the build base and the
 portrait flag into one XOR that decides whether `SCR_W`/`SCR_H` use the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ in the git log.
   without saving** (the edits are dropped), or **Cancel**. With no
   unsaved changes it sleeps immediately. `Ctrl+P` and the split
   shortcuts `Ctrl+1` / `Ctrl+2` / `Ctrl+3` now also work from the file
-  browser (a split set there shows on the next file open).
+  browser: enabling a split switches to the editor so it is visible
+  right away, and `Ctrl+1` collapses a split from anywhere (including
+  the file selector a split editor shows on Esc).
 - **Portrait display orientation** (F1 -> Settings -> "Display
   orientation": Landscape / Portrait). Portrait turns the whole UI a
   quarter turn; split-screen editing then divides the screen top/bottom
@@ -50,6 +52,11 @@ in the git log.
 
 ### Fixed
 
+- **Touch input was a quarter turn off** on any board rendering at a 90
+  or 270 degree rotation -- the natively-portrait Freenove FNK0104B /
+  FNK0104S, and any board in the new portrait orientation. The LVGL
+  display rotation fed to the touch-point transform did not match the
+  sense of the framebuffer rotation; taps now land under the finger.
 - **Xteink X4 Pro**: the flashed partition table now keeps an `otadata`
   partition and a dual-OTA app layout (`ota_0` / `ota_1`), instead of a
   single `factory` partition. The stock Xteink firmware and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ in the git log.
   FNK0104S, and any board in the new portrait orientation. The LVGL
   display rotation fed to the touch-point transform did not match the
   sense of the framebuffer rotation; taps now land under the finger.
+- **Xteink X4 Pro**: the touchscreen no longer comes up dead after a
+  restart from the Settings "restart to apply" prompt (or a panic /
+  watchdog). A warm reboot does not reset the GT911 or the I2C bus, so
+  the controller was left wedged; the GT911 is now power-cycled early
+  in boot, before the I2C bus is created.
 - **Xteink X4 Pro**: the flashed partition table now keeps an `otadata`
   partition and a dual-OTA app layout (`ota_0` / `ota_1`), instead of a
   single `factory` partition. The stock Xteink firmware and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,17 @@ in the git log.
 - **Ctrl+P puts the device into deep sleep.** If the open document has
   unsaved changes the editor first asks: **Save and sleep**, **Sleep
   without saving** (the edits are dropped), or **Cancel**. With no
-  unsaved changes it sleeps immediately.
+  unsaved changes it sleeps immediately. `Ctrl+P` and the split
+  shortcuts `Ctrl+1` / `Ctrl+2` / `Ctrl+3` now also work from the file
+  browser (a split set there shows on the next file open).
 - **Portrait display orientation** (F1 -> Settings -> "Display
-  orientation": Landscape / Portrait). Portrait turns the whole UI
-  another 90 degrees; split-screen editing then divides the screen
-  top/bottom instead of left/right, since the split always follows the
-  display's long side. Takes effect after a restart (the editor offers
-  one on the way out of Settings), the same as the screen margins.
+  orientation": Landscape / Portrait). Portrait turns the whole UI a
+  quarter turn; split-screen editing then divides the screen top/bottom
+  instead of left/right, since the split always follows the display's
+  long side. Takes effect after a restart (the editor offers one on the
+  way out of Settings), the same as the screen margins. On the Xteink
+  X4 Pro portrait turns the opposite way from the other boards, to suit
+  the enclosure.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ in the git log.
   unsaved changes the editor first asks: **Save and sleep**, **Sleep
   without saving** (the edits are dropped), or **Cancel**. With no
   unsaved changes it sleeps immediately.
+- **Portrait display orientation** (F1 -> Settings -> "Display
+  orientation": Landscape / Portrait). Portrait turns the whole UI
+  another 90 degrees; split-screen editing then divides the screen
+  top/bottom instead of left/right, since the split always follows the
+  display's long side. Takes effect after a restart (the editor offers
+  one on the way out of Settings), the same as the screen margins.
 
 ### Changed
 
@@ -31,9 +37,6 @@ in the git log.
   without saving" genuinely discards the unsaved edits. An *automatic*
   sleep on the inactivity timeout still saves everything first, as
   before.
-
-### Changed
-
 - **Crash-safe file writes.** Saving a document (and its cursor/scroll
   sidecar, and files written by Git sync) now writes to a temporary
   file that is flushed to the MicroSD card and then renamed over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,11 @@ in the git log.
   sense of the framebuffer rotation; taps now land under the finger.
 - **Xteink X4 Pro**: the touchscreen no longer comes up dead after a
   restart from the Settings "restart to apply" prompt (or a panic /
-  watchdog). A warm reboot does not reset the GT911 or the I2C bus, so
-  the controller was left wedged; the GT911 is now power-cycled early
-  in boot, before the I2C bus is created.
+  watchdog). A warm reboot does not reset the GT911, which then came
+  back stuck at its fallback I2C address and never scanning; the
+  controller is now fully power-cycled and hardware-reset with the
+  datasheet address-select timing early in boot, before the shared I2C
+  bus is created.
 - **Xteink X4 Pro**: the flashed partition table now keeps an `otadata`
   partition and a dual-OTA app layout (`ota_0` / `ota_1`), instead of a
   single `factory` partition. The stock Xteink firmware and the

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ load the firmware quickly without having to compile it.
 | Ctrl+Tab | Move keyboard focus to the other pane (when split) |
 | Escape | Switch to file browser. With unsaved changes, a dialog offers Save and exit / Exit without saving / Cancel (Up/Down + Enter to choose) |
 
+`Ctrl+P` and `Ctrl+1` / `Ctrl+2` / `Ctrl+3` also work in the file
+browser (the split layout applies the next time you open a file).
+
 
 
 ## Sleep

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ load the firmware quickly without having to compile it.
 - **Split screen editing**: You can split the screen in two equal
   halves, or 1/3 and 2/3 parts, and use a second file for side notes
   or comments. Draftling supports also editing thge same file in both
-  windows.
+  windows. The split follows the display's long side -- left/right in
+  landscape, top/bottom in portrait.
+
+- **Portrait or landscape**: F1 -> Settings -> "Display orientation"
+  turns the whole UI 90 degrees. Takes effect after a restart.
 
 - **Synchronizing your files with a Git repository** using a real,
   built-in Git client that speaks the standard smart-HTTP protocol
@@ -113,9 +117,9 @@ load the firmware quickly without having to compile it.
 | Ctrl+B | Cycle backlight / front-light brightness (boards with a controllable backlight) |
 | Ctrl+Home/End | Start / end of document |
 | Ctrl+Left/Right | Word movement |
-| Ctrl+1 | Single-pane mode (full-width editor) |
-| Ctrl+2 | Split screen into two equal-width panes |
-| Ctrl+3 | Split with the left pane at 2/3 width; press again to toggle the left pane to 1/3 |
+| Ctrl+1 | Single-pane mode (full editor) |
+| Ctrl+2 | Split into two equal panes (left/right in landscape, top/bottom in portrait) |
+| Ctrl+3 | Split with the first pane at 2/3; press again to toggle the first pane to 1/3 |
 | Ctrl+Tab | Move keyboard focus to the other pane (when split) |
 | Escape | Switch to file browser. With unsaved changes, a dialog offers Save and exit / Exit without saving / Cancel (Up/Down + Enter to choose) |
 
@@ -160,10 +164,15 @@ immediately; connect your new keyboard and it will pair automatically.
 
 ## Split-screen Editing
 
-The editor can show two documents side by side. **Ctrl+2** divides the
-screen into two equal-width vertical panes; **Ctrl+3** makes the left
-pane wider (2/3 of the width) and a second **Ctrl+3** flips the left
-pane to 1/3. **Ctrl+1** returns to a single full-width pane.
+The editor can show two documents at once. **Ctrl+2** divides the
+screen into two equal panes; **Ctrl+3** makes the first pane bigger
+(2/3) and a second **Ctrl+3** flips it to 1/3. **Ctrl+1** returns to a
+single pane.
+
+The split always divides the display's **long side**: in landscape you
+get left / right panes, in portrait (F1 -> Settings -> "Display
+orientation") you get top / bottom panes. "First pane" is the left one
+in landscape, the top one in portrait.
 
 Each pane opens a file for itself: while split, **Ctrl+O** opens the
 file browser for the focused pane, so the picked file loads into that

--- a/firmware/components/display/CMakeLists.txt
+++ b/firmware/components/display/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "display_rlcd.cpp" "display_epdiy.cpp" "display_h752.cpp" "epd_board_papers3.c" "display_axs15231b.cpp" "display_mipi_dsi.cpp" "display_rgb.cpp" "display_ili9341.cpp" "display_xteink_epd.cpp" "display_ssd1683.cpp" "display_margins.cpp" "lvgl_port.cpp"
+    SRCS "display_rlcd.cpp" "display_epdiy.cpp" "display_h752.cpp" "epd_board_papers3.c" "display_axs15231b.cpp" "display_mipi_dsi.cpp" "display_rgb.cpp" "display_ili9341.cpp" "display_xteink_epd.cpp" "display_ssd1683.cpp" "display_margins.cpp" "display_orientation.cpp" "lvgl_port.cpp"
     INCLUDE_DIRS "include"
     ## ESP-IDF 6.0 removed the legacy `driver` component's public
     ## dependencies on the split `esp_driver_*` components (see the

--- a/firmware/components/display/display_orientation.cpp
+++ b/firmware/components/display/display_orientation.cpp
@@ -1,0 +1,50 @@
+#include "display_orientation.h"
+
+#include <nvs.h>
+#include <nvs_flash.h>
+
+static const char *NVS_NS       = "disporient";
+static const char *NVS_KEY_PORT = "portrait";
+
+/* Frozen for the life of the session -- see the "why frozen" comment
+ * in display_orientation.h. Set once by display_orientation_init(). */
+static bool s_portrait = false;
+
+static bool read_pending(void)
+{
+    bool v = false;
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS, NVS_READONLY, &h) == ESP_OK) {
+        uint8_t u = 0;
+        if (nvs_get_u8(h, NVS_KEY_PORT, &u) == ESP_OK) v = (u != 0);
+        nvs_close(h);
+    }
+    return v;
+}
+
+extern "C" void display_orientation_init(void)
+{
+    s_portrait = read_pending();
+}
+
+extern "C" bool display_orientation_is_portrait(void)
+{
+    return s_portrait;
+}
+
+extern "C" void display_orientation_set_portrait(bool portrait)
+{
+    /* Deliberately does NOT touch s_portrait -- only the NEXT boot's
+     * display_orientation_init() picks this up (see display_orientation.h). */
+    nvs_handle_t h;
+    if (nvs_open(NVS_NS, NVS_READWRITE, &h) == ESP_OK) {
+        nvs_set_u8(h, NVS_KEY_PORT, portrait ? 1 : 0);
+        nvs_commit(h);
+        nvs_close(h);
+    }
+}
+
+extern "C" bool display_orientation_get_pending_portrait(void)
+{
+    return read_pending();
+}

--- a/firmware/components/display/include/display_orientation.h
+++ b/firmware/components/display/include/display_orientation.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+/*
+ * User-selectable display orientation: landscape (the default on every
+ * board) or portrait (the whole UI rotated another 90 degrees on top of
+ * the board's build-time base rotation).
+ *
+ * Like the screen margins (display_margins.h), this is FROZEN for the
+ * life of the session: the LVGL display resolution and the entire
+ * widget tree are built once at boot from this value, so a change only
+ * takes effect after a restart. main.cpp calls
+ * display_orientation_init() once, right after display_margins_init()
+ * and before draftling_lvgl_port_init(), so every consumer -- the LVGL
+ * rotation angle, the editor's SCR_W / SCR_H, the split-screen axis --
+ * sees one consistent value for the rest of the session.
+ *
+ * display_orientation_is_portrait() always returns that frozen copy,
+ * NOT whatever was most recently saved via
+ * display_orientation_set_portrait(); the Settings UI tracks the
+ * pending value itself (display_orientation_get_pending_portrait()).
+ */
+void display_orientation_init(void);
+
+/* Frozen session value: true = portrait, false = landscape. */
+bool display_orientation_is_portrait(void);
+
+/* Persist a new orientation to NVS for the *next* boot's
+ * display_orientation_init() to pick up. Does NOT change what
+ * display_orientation_is_portrait() returns this session. */
+void display_orientation_set_portrait(bool portrait);
+
+/* Raw NVS-persisted value, which may differ from the frozen
+ * display_orientation_is_portrait() value if it was changed this
+ * session (it takes effect on the next restart). Used by the Settings
+ * UI to seed its pending-value state. */
+bool display_orientation_get_pending_portrait(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/components/display/lvgl_port.cpp
+++ b/firmware/components/display/lvgl_port.cpp
@@ -101,6 +101,31 @@ static void rotate_tile_rgb565(const uint16_t *src, uint16_t *dst,
     }
 }
 
+/* Translate the lvgl_port's rotation angle (s_rotate_deg, the sense
+ * used by rotate_tile_rgb565() / map_area_to_physical() above) into the
+ * lv_display_set_rotation() argument.
+ *
+ * flush_cb rotates each tile itself, with a rotation sense OPPOSITE to
+ * LVGL's own lv_display_rotate_area() / lv_display_rotate_point(). We
+ * still have to call lv_display_set_rotation() -- LVGL needs it to swap
+ * the reported resolution for the widget tree, and (the subtle part) it
+ * is also what LVGL uses to rotate incoming touch points in
+ * indev_pointer_proc() (lv_display_rotate_point(); the only consumer
+ * here, since we never enable matrix_rotation). So feed LVGL the
+ * MIRRORED quarter turn: 90 <-> 270, with 0 and 180 unchanged. Then
+ * lv_display_rotate_point()'s physical->logical map is the exact
+ * inverse of flush_cb's logical->physical pixel map, and a tap lands
+ * where the finger is in every orientation (portrait included). */
+static lv_display_rotation_t lvgl_rotation_for_port_deg(int port_deg)
+{
+    switch ((360 - ((port_deg % 360) + 360) % 360) % 360) {
+    case 90:  return LV_DISPLAY_ROTATION_90;
+    case 180: return LV_DISPLAY_ROTATION_180;
+    case 270: return LV_DISPLAY_ROTATION_270;
+    default:  return LV_DISPLAY_ROTATION_0;
+    }
+}
+
 /* Map the LVGL (logical, post-rotation) tile area to physical panel
  * coordinates and dimensions. */
 static void map_area_to_physical(const lv_area_t *area, int rotate_deg,
@@ -278,15 +303,9 @@ extern "C" void draftling_lvgl_port_init(int width, int height, int rotate_deg)
     lv_display_set_color_format(disp, LV_COLOR_FORMAT_RGB565);
     lv_display_set_flush_cb(disp, flush_cb);
 
-    /* Apply display rotation */
-    lv_display_rotation_t rot = LV_DISPLAY_ROTATION_0;
-    switch (s_rotate_deg) {
-    case 90:  rot = LV_DISPLAY_ROTATION_90;  break;
-    case 180: rot = LV_DISPLAY_ROTATION_180; break;
-    case 270: rot = LV_DISPLAY_ROTATION_270; break;
-    default:  rot = LV_DISPLAY_ROTATION_0;   break;
-    }
-    lv_display_set_rotation(disp, rot);
+    /* Apply display rotation (see lvgl_rotation_for_port_deg for why
+     * this is the mirrored quarter turn, not s_rotate_deg directly). */
+    lv_display_set_rotation(disp, lvgl_rotation_for_port_deg(s_rotate_deg));
 
 #if defined(CONFIG_DRAFTLING_DISPLAY_EPD) || \
     defined(CONFIG_DRAFTLING_DISPLAY_COLOR)
@@ -352,14 +371,7 @@ extern "C" void draftling_lvgl_port_set_flip180(bool flip)
     s_flip180    = flip;
     s_rotate_deg = (s_base_rotate_deg + (flip ? 180 : 0)) % 360;
 
-    lv_display_rotation_t rot = LV_DISPLAY_ROTATION_0;
-    switch (s_rotate_deg) {
-    case 90:  rot = LV_DISPLAY_ROTATION_90;  break;
-    case 180: rot = LV_DISPLAY_ROTATION_180; break;
-    case 270: rot = LV_DISPLAY_ROTATION_270; break;
-    default:  rot = LV_DISPLAY_ROTATION_0;   break;
-    }
-    lv_display_set_rotation(s_disp, rot);
+    lv_display_set_rotation(s_disp, lvgl_rotation_for_port_deg(s_rotate_deg));
 
     /* Repaint everything in the new orientation. display_clear() also
      * flags the next flush as a full refresh on backends that track

--- a/firmware/components/editor/editor_ui.cpp
+++ b/firmware/components/editor/editor_ui.cpp
@@ -5684,26 +5684,28 @@ static void handle_browser_key(const kb_event_t *ev)
     if (ctrl) {
         char ck = kb_layout_shortcut_char(ev->keycode);
 
-        /* Ctrl+1 / Ctrl+2 / Ctrl+3 set up the split layout (HID
-         * keycodes 1 = 0x1E, 2 = 0x1F, 3 = 0x20). The panes live on
-         * the editor screen, so from the browser this only updates the
-         * layout + NVS; it becomes visible the next time a file is
-         * opened. */
+        /* Ctrl+1 / Ctrl+2 / Ctrl+3 control the split layout (HID
+         * keycodes 1 = 0x1E, 2 = 0x1F, 3 = 0x20). The panes are on the
+         * editor screen, so enabling a split here switches straight to
+         * the editor so the change is visible immediately (Ctrl+O in a
+         * pane then picks its file). Ctrl+1 with nothing to collapse
+         * just stays on the browser. */
         if (ev->keycode == 0x1E) {            /* Ctrl+1: single pane */
+            /* The full-screen browser only shows in single-pane mode
+             * (a split editor shows the in-pane selector on Esc), so
+             * this just confirms the mode + persists it. */
             editor_ui_apply_split_mode(SPLIT_NONE);
             editor_ui_set_status("Split: single pane");
             return;
         }
         if (ev->keycode == 0x1F) {            /* Ctrl+2: equal split */
             editor_ui_apply_split_mode(SPLIT_HALF);
-            if (s_pane_count > 1)
-                editor_ui_set_status("Split: two panes (shown on next open)");
+            if (s_pane_count > 1) editor_ui_show_editor();
             return;
         }
         if (ev->keycode == 0x20) {            /* Ctrl+3: 2/3 <-> 1/3 */
             editor_ui_cycle_wide_split();
-            if (s_pane_count > 1)
-                editor_ui_set_status("Split: 2/3 + 1/3 (shown on next open)");
+            if (s_pane_count > 1) editor_ui_show_editor();
             return;
         }
 
@@ -5863,12 +5865,19 @@ static void handle_inpane_browser_key(const kb_event_t *ev)
         return;
     }
 
-    /* Ctrl+1 / Ctrl+2 / Ctrl+3 change the split layout, which would
-     * pull the rug out from under this overlay (it lives on the split
-     * editor screen). Ignore them here -- the user can adjust the split
-     * from the editor or the full-screen browser. */
+    /* Ctrl+1 / Ctrl+2 / Ctrl+3 change the split layout. This overlay
+     * lives on the split editor screen, so close it and re-apply the
+     * layout (editor_ui_apply_split_mode() repaints and returns key
+     * routing to handle_editor_key). Ctrl+1 in particular is how the
+     * user collapses a split they entered by mistake, and it must work
+     * from here -- a split editor shows this overlay, not the
+     * full-screen browser, on Esc. */
     if (ctrl && (ev->keycode == 0x1E || ev->keycode == 0x1F ||
                  ev->keycode == 0x20)) {
+        close_inpane_browser();
+        if      (ev->keycode == 0x1E) editor_ui_apply_split_mode(SPLIT_NONE);
+        else if (ev->keycode == 0x1F) editor_ui_apply_split_mode(SPLIT_HALF);
+        else                          editor_ui_cycle_wide_split();
         return;
     }
 

--- a/firmware/components/editor/editor_ui.cpp
+++ b/firmware/components/editor/editor_ui.cpp
@@ -88,10 +88,12 @@ static const char *TAG = "EditorUI";
  * when the board's build-time base rotation
  * (CONFIG_DRAFTLING_DISPLAY_ROTATE_ANGLE) is 90/270, OR when the user
  * picked portrait orientation (Settings -> Display orientation, which
- * adds another 90 degrees), but not both -- an XOR.
- * display_orientation_is_portrait() is frozen for the session (see
- * display_orientation.h), so SCR_W / SCR_H stay constant until the
- * next restart, exactly like the margins. */
+ * adds a quarter turn -- 90 or 270 degrees, per
+ * CONFIG_DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE), but not both -- an
+ * XOR (both 90 and 270 flip the swap either way, so the exact quarter
+ * turn does not matter here). display_orientation_is_portrait() is
+ * frozen for the session (see display_orientation.h), so SCR_W / SCR_H
+ * stay constant until the next restart, exactly like the margins. */
 #if CONFIG_DRAFTLING_DISPLAY_ROTATE_ANGLE == 90 || CONFIG_DRAFTLING_DISPLAY_ROTATE_ANGLE == 270
 static inline bool scr_axes_swapped(void) { return !display_orientation_is_portrait(); }
 #else
@@ -5675,11 +5677,42 @@ static void handle_browser_key(const kb_event_t *ev)
         return;
     }
 
-    /* Ctrl+G / Ctrl+W work from the file browser as well. See the
-     * editor's Ctrl-shortcut block for why kb_layout_shortcut_char()
-     * is used instead of a raw layout translation. */
+    /* Ctrl+G / Ctrl+W / Ctrl+M / Ctrl+P and the Ctrl+1/2/3 split
+     * shortcuts work from the file browser as well. See the editor's
+     * Ctrl-shortcut block for why kb_layout_shortcut_char() is used
+     * instead of a raw layout translation. */
     if (ctrl) {
         char ck = kb_layout_shortcut_char(ev->keycode);
+
+        /* Ctrl+1 / Ctrl+2 / Ctrl+3 set up the split layout (HID
+         * keycodes 1 = 0x1E, 2 = 0x1F, 3 = 0x20). The panes live on
+         * the editor screen, so from the browser this only updates the
+         * layout + NVS; it becomes visible the next time a file is
+         * opened. */
+        if (ev->keycode == 0x1E) {            /* Ctrl+1: single pane */
+            editor_ui_apply_split_mode(SPLIT_NONE);
+            editor_ui_set_status("Split: single pane");
+            return;
+        }
+        if (ev->keycode == 0x1F) {            /* Ctrl+2: equal split */
+            editor_ui_apply_split_mode(SPLIT_HALF);
+            if (s_pane_count > 1)
+                editor_ui_set_status("Split: two panes (shown on next open)");
+            return;
+        }
+        if (ev->keycode == 0x20) {            /* Ctrl+3: 2/3 <-> 1/3 */
+            editor_ui_cycle_wide_split();
+            if (s_pane_count > 1)
+                editor_ui_set_status("Split: 2/3 + 1/3 (shown on next open)");
+            return;
+        }
+
+        if (ck == 'p') {
+            /* Ctrl+P: deep sleep. No editor screen to prompt on here;
+             * the standby pre-sleep hook auto-saves any open document. */
+            standby_enter_sleep();
+            return;
+        }
         if (ck == 'g') {
             if (git_sync_is_configured() && wifi_manager_is_connected()) {
                 if (git_sync_start(GIT_SYNC_BOTH) == ESP_OK) {
@@ -5827,6 +5860,15 @@ static void handle_inpane_browser_key(const kb_event_t *ev)
         close_inpane_browser();
         editor_ui_focus_other_pane();
         editor_ui_show_editor();
+        return;
+    }
+
+    /* Ctrl+1 / Ctrl+2 / Ctrl+3 change the split layout, which would
+     * pull the rug out from under this overlay (it lives on the split
+     * editor screen). Ignore them here -- the user can adjust the split
+     * from the editor or the full-screen browser. */
+    if (ctrl && (ev->keycode == 0x1E || ev->keycode == 0x1F ||
+                 ev->keycode == 0x20)) {
         return;
     }
 

--- a/firmware/components/editor/editor_ui.cpp
+++ b/firmware/components/editor/editor_ui.cpp
@@ -28,6 +28,7 @@
 #include "lvgl_port.h"
 #include "display.h"
 #include "display_margins.h"
+#include "display_orientation.h"
 #include "standby.h"
 #include "greybeard.h"
 #include "battery.h"
@@ -82,14 +83,26 @@ static const char *TAG = "EditorUI";
  * default on every board -- see Settings -> Screen margins and
  * app_config.h's DISPLAY_LOGICAL_WIDTH/HEIGHT).
  *
- * At 90 or 270 degrees, the width and height are swapped. */
+ * The LVGL logical canvas has the panel's width and height swapped
+ * whenever the *effective* rotation is 90 or 270 degrees. That happens
+ * when the board's build-time base rotation
+ * (CONFIG_DRAFTLING_DISPLAY_ROTATE_ANGLE) is 90/270, OR when the user
+ * picked portrait orientation (Settings -> Display orientation, which
+ * adds another 90 degrees), but not both -- an XOR.
+ * display_orientation_is_portrait() is frozen for the session (see
+ * display_orientation.h), so SCR_W / SCR_H stay constant until the
+ * next restart, exactly like the margins. */
 #if CONFIG_DRAFTLING_DISPLAY_ROTATE_ANGLE == 90 || CONFIG_DRAFTLING_DISPLAY_ROTATE_ANGLE == 270
-#define SCR_W        (CONFIG_DRAFTLING_DISPLAY_HEIGHT - display_margin_top() - display_margin_bottom())
-#define SCR_H        (CONFIG_DRAFTLING_DISPLAY_WIDTH  - display_margin_left() - display_margin_right())
+static inline bool scr_axes_swapped(void) { return !display_orientation_is_portrait(); }
 #else
-#define SCR_W        (CONFIG_DRAFTLING_DISPLAY_WIDTH  - display_margin_left() - display_margin_right())
-#define SCR_H        (CONFIG_DRAFTLING_DISPLAY_HEIGHT - display_margin_top() - display_margin_bottom())
+static inline bool scr_axes_swapped(void) { return display_orientation_is_portrait(); }
 #endif
+#define SCR_W        (scr_axes_swapped() \
+    ? (CONFIG_DRAFTLING_DISPLAY_HEIGHT - display_margin_top()  - display_margin_bottom()) \
+    : (CONFIG_DRAFTLING_DISPLAY_WIDTH  - display_margin_left() - display_margin_right()))
+#define SCR_H        (scr_axes_swapped() \
+    ? (CONFIG_DRAFTLING_DISPLAY_WIDTH  - display_margin_left() - display_margin_right()) \
+    : (CONFIG_DRAFTLING_DISPLAY_HEIGHT - display_margin_top()  - display_margin_bottom()))
 /* Header / status bar heights. These bars always use FONT_11, so on
  * high-density boards (which render 1:1 with the taller Hack font
  * instead of the old 2x upscale) they must be twice as tall to fit the
@@ -600,20 +613,27 @@ static void save_active_layouts_to_nvs(void)
  * display_margins.h). */
 static int s_margin_left = 0, s_margin_right = 0, s_margin_top = 0, s_margin_bottom = 0;
 
-/* Set whenever a margin value is cycled during the current Settings
- * visit; drives the "restart now?" prompt shown on the way out (see
- * request_close_settings() / s_margin_confirm_open below), since that
+/* Pending display orientation (Settings -> Display orientation). Like
+ * the margins, this is frozen for the session (see
+ * display_orientation.h); this local tracks the NVS-persisted value
+ * that will apply on the next restart. */
+static bool s_pending_portrait = false;
+
+/* Set whenever a restart-only display setting -- a margin, or the
+ * display orientation -- is changed during the current Settings visit;
+ * drives the "restart now?" prompt shown on the way out (see
+ * request_close_settings() / s_restart_confirm_open below), since that
  * is the earliest point a restart can be applied without yanking the
- * user out of the middle of adjusting margins. */
-static bool s_margins_changed = false;
+ * user out of the middle of adjusting settings. */
+static bool s_restart_needed = false;
 
 /* Full-takeover confirmation shown by request_close_settings() when
- * leaving the Settings screen with a pending margin change -- same
- * one-widget-list-reused pattern as the color-theme picker below.
+ * leaving the Settings screen with a pending restart-only change --
+ * same one-widget-list-reused pattern as the color-theme picker below.
  * sel 0 = restart now, 1 = keep editing and apply later. */
-static bool s_margin_confirm_open     = false;
-static int  s_margin_confirm_sel      = 0;
-static int  s_margin_confirm_sel_prev = -1;
+static bool s_restart_confirm_open     = false;
+static int  s_restart_confirm_sel      = 0;
+static int  s_restart_confirm_sel_prev = -1;
 
 static void load_margins_from_nvs(void)
 {
@@ -945,8 +965,15 @@ static const char *TIMEOUT_LABELS[]     = { "Off", "5 min", "10 min",
                                             "15 min", "30 min", "60 min" };
 #define TIMEOUT_OPTION_COUNT  6
 
-/* Line label pool */
-#define MAX_LINE_LABELS 24
+/* Line label pool. Sized to fill the editor body on the smaller
+ * panels in portrait orientation (Settings -> Display orientation),
+ * where the tall side becomes the editor height -- e.g. the Xteink X4
+ * Pro is ~19 body rows tall in landscape but ~33 in portrait. The
+ * largest panels (Tab5, 7" Sunton) still cap the visible-line count in
+ * portrait, the same way they already do in landscape. Each extra slot
+ * costs one lazily-created LVGL label per pane plus a small struct
+ * entry -- see pane_t. */
+#define MAX_LINE_LABELS 40
 
 /* A "line" here is one source paragraph (run between '\n's) which can
  * be arbitrarily long, so the rendered text for a slot must NOT be
@@ -1019,14 +1046,20 @@ static pane_t *s_rp          = &s_panes[0];  /* current render / active pane */
 static int     s_pane_count  = 1;            /* 1 = single, 2 = split */
 static int     s_focus       = 0;            /* focused pane index (0..count-1) */
 
-/* Split layout: single pane, or a vertical (left / right) split with
- * the left pane occupying 1/2, 2/3 or 1/3 of the usable width. Driven
- * by the Ctrl+1 / Ctrl+2 / Ctrl+3 shortcuts. */
+/* Split layout: single pane, or a two-pane split along the display's
+ * long axis with the first pane occupying 1/2, 2/3 or 1/3 of it.
+ * Driven by the Ctrl+1 / Ctrl+2 / Ctrl+3 shortcuts.
+ *
+ * "First" is the left pane in landscape and the top pane in portrait
+ * (Settings -> Display orientation) -- the split always divides the
+ * long side, so a portrait screen splits into top/bottom rather than
+ * left/right. The SPLIT_LEFT_* names are historical; read them as
+ * "first pane = 2/3" etc. */
 typedef enum {
-    SPLIT_NONE = 0,   /* single pane (full width) */
-    SPLIT_HALF,       /* two panes, left = 1/2 */
-    SPLIT_LEFT_2_3,   /* two panes, left = 2/3 */
-    SPLIT_LEFT_1_3,   /* two panes, left = 1/3 */
+    SPLIT_NONE = 0,   /* single pane (full size) */
+    SPLIT_HALF,       /* two panes, first = 1/2 */
+    SPLIT_LEFT_2_3,   /* two panes, first = 2/3 */
+    SPLIT_LEFT_1_3,   /* two panes, first = 1/3 */
 } split_mode_t;
 static split_mode_t s_split_mode = SPLIT_NONE;
 
@@ -1205,13 +1238,31 @@ static void epd_full_screen_repaint(void)
 }
 #endif
 
+/* First pane's share (numerator/3, or /2 for HALF) of the usable long
+ * axis for the current split mode. */
+static void split_first_fraction(int total, int *first)
+{
+    switch (s_split_mode) {
+    case SPLIT_LEFT_2_3: *first = (total * 2) / 3; break;
+    case SPLIT_LEFT_1_3: *first = total / 3;       break;
+    case SPLIT_HALF:
+    default:             *first = total / 2;       break;
+    }
+    if (*first < 1) *first = 1;
+    if (*first > total - 1) *first = total - 1;
+}
+
 /* Recompute each pane's content-area rectangle from the current split
  * state. The editor body occupies [EDITOR_Y, EDITOR_Y + EDITOR_H). A
- * single pane fills it entirely; a vertical split places two panes
- * side by side (left / right) with a 1 px vertical divider between
- * them. Both panes keep the full editor height; only their width and
- * x-offset differ, so each pane wraps text to its own narrower width.
- * The left pane's share of the usable width is set by s_split_mode. */
+ * single pane fills it entirely; a two-pane split divides the display's
+ * long axis with a 1 px divider between the panes:
+ *
+ *   - landscape: left / right panes (vary x + width, full height), so
+ *     each pane wraps text to its own narrower width;
+ *   - portrait (Settings -> Display orientation): top / bottom panes
+ *     (vary y + height, full width), so each pane shows fewer rows.
+ *
+ * The first pane's share of the long axis is set by s_split_mode. */
 static void recalc_pane_geometry(void)
 {
     if (s_pane_count <= 1) {
@@ -1225,16 +1276,28 @@ static void recalc_pane_geometry(void)
         s_panes[1].h = EDITOR_H;
         return;
     }
-    int total = SCR_W - 1;             /* 1 px reserved for the divider */
-    int left_w;
-    switch (s_split_mode) {
-    case SPLIT_LEFT_2_3: left_w = (total * 2) / 3; break;
-    case SPLIT_LEFT_1_3: left_w = total / 3;       break;
-    case SPLIT_HALF:
-    default:             left_w = total / 2;       break;
+
+    if (display_orientation_is_portrait()) {
+        /* Top / bottom split: vary y + height, full width. */
+        int total = EDITOR_H - 1;     /* 1 px reserved for the divider */
+        int top_h;
+        split_first_fraction(total, &top_h);
+        int bot_h = total - top_h;
+        s_panes[0].x = 0;
+        s_panes[0].w = SCR_W;
+        s_panes[0].y = EDITOR_Y;
+        s_panes[0].h = top_h;
+        s_panes[1].x = 0;
+        s_panes[1].w = SCR_W;
+        s_panes[1].y = EDITOR_Y + top_h + 1;
+        s_panes[1].h = bot_h;
+        return;
     }
-    if (left_w < 1) left_w = 1;
-    if (left_w > total - 1) left_w = total - 1;
+
+    /* Left / right split: vary x + width, full height. */
+    int total = SCR_W - 1;            /* 1 px reserved for the divider */
+    int left_w;
+    split_first_fraction(total, &left_w);
     int right_w = total - left_w;
     s_panes[0].x = 0;
     s_panes[0].w = left_w;
@@ -1266,8 +1329,15 @@ static void layout_panes(void)
     }
     if (s_pane_divider) {
         if (s_pane_count > 1) {
-            lv_obj_set_pos(s_pane_divider, s_panes[0].x + s_panes[0].w, EDITOR_Y);
-            lv_obj_set_size(s_pane_divider, 1, EDITOR_H);
+            if (display_orientation_is_portrait()) {
+                /* Horizontal rule between the top and bottom panes. */
+                lv_obj_set_pos(s_pane_divider, 0, s_panes[0].y + s_panes[0].h);
+                lv_obj_set_size(s_pane_divider, SCR_W, 1);
+            } else {
+                /* Vertical rule between the left and right panes. */
+                lv_obj_set_pos(s_pane_divider, s_panes[0].x + s_panes[0].w, EDITOR_Y);
+                lv_obj_set_size(s_pane_divider, 1, EDITOR_H);
+            }
             lv_obj_remove_flag(s_pane_divider, LV_OBJ_FLAG_HIDDEN);
         } else {
             lv_obj_add_flag(s_pane_divider, LV_OBJ_FLAG_HIDDEN);
@@ -3306,14 +3376,15 @@ static int find_timeout_option(uint32_t sec)
 #endif
 #define SETTINGS_IDX_APPEND_ONLY   (_SETTINGS_NEXT_AFTER_INVERT + 0)
 #define SETTINGS_IDX_LAYOUTS       (_SETTINGS_NEXT_AFTER_INVERT + 1)
-#define SETTINGS_IDX_MARGIN_LEFT   (_SETTINGS_NEXT_AFTER_INVERT + 2)
-#define SETTINGS_IDX_MARGIN_RIGHT  (_SETTINGS_NEXT_AFTER_INVERT + 3)
-#define SETTINGS_IDX_MARGIN_TOP    (_SETTINGS_NEXT_AFTER_INVERT + 4)
-#define SETTINGS_IDX_MARGIN_BOTTOM (_SETTINGS_NEXT_AFTER_INVERT + 5)
+#define SETTINGS_IDX_ORIENTATION   (_SETTINGS_NEXT_AFTER_INVERT + 2)
+#define SETTINGS_IDX_MARGIN_LEFT   (_SETTINGS_NEXT_AFTER_INVERT + 3)
+#define SETTINGS_IDX_MARGIN_RIGHT  (_SETTINGS_NEXT_AFTER_INVERT + 4)
+#define SETTINGS_IDX_MARGIN_TOP    (_SETTINGS_NEXT_AFTER_INVERT + 5)
+#define SETTINGS_IDX_MARGIN_BOTTOM (_SETTINGS_NEXT_AFTER_INVERT + 6)
 /* "Sleep now" used to live here; it now lives in the F1 menu. */
-#define SETTINGS_IDX_RESET    (_SETTINGS_NEXT_AFTER_INVERT + 6)
-#define SETTINGS_IDX_BACK     (_SETTINGS_NEXT_AFTER_INVERT + 7)
-#define SETTINGS_ITEM_COUNT   (_SETTINGS_NEXT_AFTER_INVERT + 8)
+#define SETTINGS_IDX_RESET    (_SETTINGS_NEXT_AFTER_INVERT + 7)
+#define SETTINGS_IDX_BACK     (_SETTINGS_NEXT_AFTER_INVERT + 8)
+#define SETTINGS_ITEM_COUNT   (_SETTINGS_NEXT_AFTER_INVERT + 9)
 
 static void refresh_settings_items(void)
 {
@@ -3391,6 +3462,13 @@ static void refresh_settings_items(void)
         snprintf(buf, sizeof(buf), "Active layouts: %s (Enter to edit)", names);
         lv_list_add_btn(s_settings_list, NULL, buf);
     }
+
+    /* Display orientation -- landscape (default) or portrait (the whole
+     * UI turned another 90 degrees). Frozen for the session like the
+     * margins below, so it only takes effect on a restart. */
+    snprintf(buf, sizeof(buf), "Display orientation: %s (restart to apply)",
+             s_pending_portrait ? "Portrait" : "Landscape");
+    lv_list_add_btn(s_settings_list, NULL, buf);
 
     /* Screen margins -- pixels of panel hidden under the enclosure on
      * each edge. Zero by default; the LVGL display resolution is fixed
@@ -3514,41 +3592,43 @@ static void close_layouts_picker(void)
     refresh_settings_items();
 }
 
-/* ---- Margin-change restart prompt ----
+/* ---- Restart-to-apply prompt ----
  * Renders into the same s_settings_list widget while
- * s_margin_confirm_open is true -- same reused-list pattern as the
- * color-theme picker above. Shown by request_close_settings() when
- * the user leaves the Settings screen having cycled at least one
- * margin this visit. */
-static void refresh_margin_confirm_items(void)
+ * s_restart_confirm_open is true -- same reused-list pattern as the
+ * color-theme picker above. Shown by request_close_settings() when the
+ * user leaves the Settings screen having changed a restart-only
+ * display setting this visit (a margin, or the display orientation). */
+static void refresh_restart_confirm_items(void)
 {
     lv_obj_clean(s_settings_list);
-    lv_list_add_btn(s_settings_list, NULL, "Restart now to apply margins");
+    lv_list_add_btn(s_settings_list, NULL, "Restart now to apply changes");
     lv_list_add_btn(s_settings_list, NULL, "Keep editing (apply later)");
-    apply_list_selection_styles(s_settings_list, s_margin_confirm_sel);
-    s_margin_confirm_sel_prev = s_margin_confirm_sel;
+    apply_list_selection_styles(s_settings_list, s_restart_confirm_sel);
+    s_restart_confirm_sel_prev = s_restart_confirm_sel;
 }
 
-static void update_margin_confirm_highlight(void)
+static void update_restart_confirm_highlight(void)
 {
-    update_list_highlight(s_settings_list, s_margin_confirm_sel,
-                          s_margin_confirm_sel_prev);
-    s_margin_confirm_sel_prev = s_margin_confirm_sel;
+    update_list_highlight(s_settings_list, s_restart_confirm_sel,
+                          s_restart_confirm_sel_prev);
+    s_restart_confirm_sel_prev = s_restart_confirm_sel;
 }
 
 static void close_settings(void);
 
-/* Leaves the Settings screen, but if a margin was cycled this visit,
- * offers to restart immediately instead of closing straight away --
- * the LVGL display resolution is fixed for the session (see
- * display_margins.h), so a restart is the only way to make the new
- * margin visible without waiting for the next natural reboot/wake. */
+/* Leaves the Settings screen, but if a restart-only display setting (a
+ * margin or the display orientation) was changed this visit, offers to
+ * restart immediately instead of closing straight away -- the LVGL
+ * display resolution and rotation are fixed for the session (see
+ * display_margins.h / display_orientation.h), so a restart is the only
+ * way to apply the change without waiting for the next natural
+ * reboot/wake. */
 static void request_close_settings(void)
 {
-    if (s_margins_changed) {
-        s_margin_confirm_open = true;
-        s_margin_confirm_sel = 0;
-        refresh_margin_confirm_items();
+    if (s_restart_needed) {
+        s_restart_confirm_open = true;
+        s_restart_confirm_sel = 0;
+        refresh_restart_confirm_items();
         return;
     }
     close_settings();
@@ -3560,8 +3640,8 @@ static void show_settings(void)
     s_menu_open = false;
     s_settings_sel = 0;
     s_factory_reset_confirm = false;
-    s_margins_changed = false;
-    s_margin_confirm_open = false;
+    s_restart_needed = false;
+    s_restart_confirm_open = false;
 #if defined(CONFIG_DRAFTLING_DISPLAY_COLOR)
     s_theme_picker_open = false;
 #endif
@@ -3686,12 +3766,23 @@ static bool settings_cycle_item(int idx, int dir)
         save_append_only_to_nvs();
         refresh_settings_items();
         return true;
+    } else if (idx == SETTINGS_IDX_ORIENTATION) {
+        /* Landscape <-> portrait. Only two states, so either direction
+         * toggles. Persisted to NVS for the next boot; the LVGL
+         * rotation and the whole widget tree are fixed for the session
+         * (see display_orientation.h), so request_close_settings()
+         * offers a restart on the way out. */
+        s_pending_portrait = !s_pending_portrait;
+        display_orientation_set_portrait(s_pending_portrait);
+        s_restart_needed = true;
+        refresh_settings_items();
+        return true;
     } else if (idx == SETTINGS_IDX_MARGIN_LEFT) {
         int oi = find_margin_option(s_margin_left);
         oi = (oi + dir + MARGIN_OPTION_COUNT) % MARGIN_OPTION_COUNT;
         s_margin_left = MARGIN_OPTIONS[oi];
         display_margins_set(s_margin_left, s_margin_right, s_margin_top, s_margin_bottom);
-        s_margins_changed = true;
+        s_restart_needed = true;
         refresh_settings_items();
         return true;
     } else if (idx == SETTINGS_IDX_MARGIN_RIGHT) {
@@ -3699,7 +3790,7 @@ static bool settings_cycle_item(int idx, int dir)
         oi = (oi + dir + MARGIN_OPTION_COUNT) % MARGIN_OPTION_COUNT;
         s_margin_right = MARGIN_OPTIONS[oi];
         display_margins_set(s_margin_left, s_margin_right, s_margin_top, s_margin_bottom);
-        s_margins_changed = true;
+        s_restart_needed = true;
         refresh_settings_items();
         return true;
     } else if (idx == SETTINGS_IDX_MARGIN_TOP) {
@@ -3707,7 +3798,7 @@ static bool settings_cycle_item(int idx, int dir)
         oi = (oi + dir + MARGIN_OPTION_COUNT) % MARGIN_OPTION_COUNT;
         s_margin_top = MARGIN_OPTIONS[oi];
         display_margins_set(s_margin_left, s_margin_right, s_margin_top, s_margin_bottom);
-        s_margins_changed = true;
+        s_restart_needed = true;
         refresh_settings_items();
         return true;
     } else if (idx == SETTINGS_IDX_MARGIN_BOTTOM) {
@@ -3715,7 +3806,7 @@ static bool settings_cycle_item(int idx, int dir)
         oi = (oi + dir + MARGIN_OPTION_COUNT) % MARGIN_OPTION_COUNT;
         s_margin_bottom = MARGIN_OPTIONS[oi];
         display_margins_set(s_margin_left, s_margin_right, s_margin_top, s_margin_bottom);
-        s_margins_changed = true;
+        s_restart_needed = true;
         refresh_settings_items();
         return true;
     }
@@ -3770,29 +3861,29 @@ static void settings_activate_item(int idx)
 
 static void handle_settings_key(const kb_event_t *ev)
 {
-    if (s_margin_confirm_open) {
+    if (s_restart_confirm_open) {
         switch (ev->keycode) {
         case KB_KEY_UP:
         case KB_KEY_DOWN:
-            s_margin_confirm_sel = s_margin_confirm_sel == 0 ? 1 : 0;
-            update_margin_confirm_highlight();
+            s_restart_confirm_sel = s_restart_confirm_sel == 0 ? 1 : 0;
+            update_restart_confirm_highlight();
             break;
         case KB_KEY_ENTER:
-            if (s_margin_confirm_sel == 0) {
-                ESP_LOGI(TAG, "Restarting to apply new screen margins");
+            if (s_restart_confirm_sel == 0) {
+                ESP_LOGI(TAG, "Restarting to apply new display settings");
                 esp_restart();
                 /* does not return */
             }
-            s_margin_confirm_open = false;
+            s_restart_confirm_open = false;
             close_settings();
             break;
         case KB_KEY_ESCAPE:
             /* Same as "keep editing" -- Escape leaving the user stuck
              * re-answering the same prompt would be worse than just
-             * deferring the restart, since the margin is already
+             * deferring the restart, since the new value is already
              * saved to NVS and will apply on the next natural
              * restart/sleep-wake regardless. */
-            s_margin_confirm_open = false;
+            s_restart_confirm_open = false;
             close_settings();
             break;
         default:
@@ -4794,12 +4885,15 @@ static bool cursor_line_is_rtl(void)
 
 /* ---- Split-screen control ----
  *
- * The editor shows one pane by default. The split is driven entirely
+ * The editor shows one pane by default. The split always divides the
+ * display's long axis -- left/right in landscape, top/bottom in
+ * portrait (Settings -> Display orientation) -- and is driven entirely
  * by three shortcuts:
- *   Ctrl+1  single pane (full width)
- *   Ctrl+2  two equal-width panes (left = 1/2)
- *   Ctrl+3  two panes with the left = 2/3; pressing Ctrl+3 again
- *           flips the left pane to 1/3 (and back).
+ *   Ctrl+1  single pane
+ *   Ctrl+2  two equal panes (first = 1/2)
+ *   Ctrl+3  two panes with the first = 2/3; pressing Ctrl+3 again
+ *           flips the first pane to 1/3 (and back).
+ * "First" is the left pane in landscape, the top pane in portrait.
  * Enabling a split for the first time acquires a fresh, empty untitled
  * document into pane 1; collapsing back to a single pane keeps pane 1's
  * document open in the background so re-splitting restores it. Each
@@ -4869,8 +4963,9 @@ static void editor_ui_apply_split_mode(split_mode_t mode)
 }
 
 /* Ctrl+3: enter / cycle the asymmetric split. First press (from single
- * or equal split) makes the left pane 2/3; a subsequent Ctrl+3 toggles
- * the left pane between 2/3 and 1/3. */
+ * or equal split) makes the first pane 2/3; a subsequent Ctrl+3 toggles
+ * the first pane between 2/3 and 1/3. (First pane = left in landscape,
+ * top in portrait.) */
 static void editor_ui_cycle_wide_split(void)
 {
     split_mode_t next = (s_split_mode == SPLIT_LEFT_2_3)
@@ -6029,7 +6124,7 @@ static void apply_pending_connect_state(void)
          * editor_close_file() -- preserve the user's work. */
         s_menu_open = false;
         s_settings_open = false;
-        s_margin_confirm_open = false;
+        s_restart_confirm_open = false;
 #if defined(CONFIG_DRAFTLING_DISPLAY_COLOR)
         s_theme_picker_open = false;
 #endif
@@ -6359,7 +6454,10 @@ static void build_screens(void)
     }
     pane_bind_focus();
 
-    /* Vertical divider drawn between the two panes when split. */
+    /* Divider drawn between the two panes when split -- vertical in
+     * landscape, horizontal in portrait. layout_panes() sizes and
+     * positions it for the current orientation; these are just
+     * placeholder values. */
     s_pane_divider = lv_obj_create(s_scr);
     lv_obj_set_size(s_pane_divider, 1, EDITOR_H);
     lv_obj_set_pos(s_pane_divider, SCR_W / 2, EDITOR_Y);
@@ -7049,8 +7147,8 @@ static void teardown_screens(void)
 #endif
     s_layouts_picker_open     = false;
     s_factory_reset_confirm   = false;
-    s_margins_changed         = false;
-    s_margin_confirm_open     = false;
+    s_restart_needed         = false;
+    s_restart_confirm_open     = false;
     s_save_open               = false;
     s_exit_open               = false;
     s_search_open             = false;
@@ -7128,6 +7226,7 @@ extern "C" void editor_ui_init(void)
     load_append_only_from_nvs();
     load_active_layouts_from_nvs();
     load_margins_from_nvs();
+    s_pending_portrait = display_orientation_get_pending_portrait();
     init_styles();
 
     /* Create key-event queue (must exist before BLE callback is set) */

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1069,6 +1069,18 @@ config DRAFTLING_DISPLAY_ROTATE_ANGLE
     default 180 if DRAFTLING_DISPLAY_ROTATE_180
     default 270 if DRAFTLING_DISPLAY_ROTATE_270
 
+# Degrees added on top of DRAFTLING_DISPLAY_ROTATE_ANGLE when the user
+# picks "Portrait" in F1 -> Settings -> Display orientation (see
+# app_config.h's DISPLAY_ROTATE_EFFECTIVE). 90 turns a landscape board
+# a quarter turn clockwise; 270 turns it the other way. Non-prompted
+# derived int so the per-board value tracks the hardware-model choice.
+# The Xteink X4 Pro's enclosure reads better with portrait rotated the
+# opposite way from the default.
+config DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE
+    int
+    default 270 if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default 90
+
 # DRAFTLING_DISPLAY_HIDPI -- high-density panel that renders the UI
 # 1:1 with the larger Hack font family instead of upscaling the
 # Greybeard framebuffer. Non-prompted derived bool so the per-board

--- a/firmware/main/app_config.h
+++ b/firmware/main/app_config.h
@@ -14,13 +14,17 @@
 
 /* Effective rotation handed to the LVGL port. The user-selectable
  * "Display orientation" setting (F1 -> Settings, restart to apply)
- * adds another 90 degrees on top of the base rotation for portrait,
- * turning a landscape board 90 degrees. display_orientation_init()
- * must have run (main.cpp calls it right after display_margins_init())
- * before this is evaluated. */
-#define DISPLAY_ROTATE_EFFECTIVE \
-    (display_orientation_is_portrait() ? ((DISPLAY_ROTATE + 90) % 360) \
-                                       : DISPLAY_ROTATE)
+ * adds DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE degrees (90 by default,
+ * 270 on the Xteink X4 Pro whose enclosure reads better the other way)
+ * on top of the base rotation for portrait, turning a landscape board
+ * a quarter turn. display_orientation_init() must have run (main.cpp
+ * calls it right after display_margins_init()) before this is
+ * evaluated. */
+#define DISPLAY_ROTATE_EFFECTIVE                                            \
+    (display_orientation_is_portrait()                                      \
+        ? ((DISPLAY_ROTATE + CONFIG_DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE) \
+           % 360)                                                          \
+        : DISPLAY_ROTATE)
 
 /* The editor and LVGL canvas render 1:1 at the panel resolution,
  * minus the user-adjustable margins (display_margins.h) -- pixels of

--- a/firmware/main/app_config.h
+++ b/firmware/main/app_config.h
@@ -2,11 +2,25 @@
 
 #include "sdkconfig.h"
 #include "display_margins.h"
+#include "display_orientation.h"
 
 /* Display dimensions (derived from Kconfig hardware model selection) */
 #define DISPLAY_WIDTH   CONFIG_DRAFTLING_DISPLAY_WIDTH
 #define DISPLAY_HEIGHT  CONFIG_DRAFTLING_DISPLAY_HEIGHT
+
+/* Build-time base rotation for the board's panel (0 for most boards,
+ * 90 for the natively-portrait Freenove panels, 270 for the Tab5). */
 #define DISPLAY_ROTATE  CONFIG_DRAFTLING_DISPLAY_ROTATE_ANGLE
+
+/* Effective rotation handed to the LVGL port. The user-selectable
+ * "Display orientation" setting (F1 -> Settings, restart to apply)
+ * adds another 90 degrees on top of the base rotation for portrait,
+ * turning a landscape board 90 degrees. display_orientation_init()
+ * must have run (main.cpp calls it right after display_margins_init())
+ * before this is evaluated. */
+#define DISPLAY_ROTATE_EFFECTIVE \
+    (display_orientation_is_portrait() ? ((DISPLAY_ROTATE + 90) % 360) \
+                                       : DISPLAY_ROTATE)
 
 /* The editor and LVGL canvas render 1:1 at the panel resolution,
  * minus the user-adjustable margins (display_margins.h) -- pixels of

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -1333,6 +1333,16 @@ extern "C" void app_main(void)
     t5_release_held_gpios_after_wake();
 #endif
 #if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO)
+    /* pre_sleep_xteink_x4_pro_deinit() calls gpio_deep_sleep_hold_en()
+     * before deep sleep, which on the ESP32-S3 keeps the digital GPIO
+     * output levels latched into the next startup -- and stays latched
+     * until gpio_deep_sleep_hold_dis() is called. Release it here, on
+     * every boot, so the display / touch / SD bring-up below can drive
+     * the peripheral-rail and power-enable pads freely (in particular
+     * the GT911 power-cycle further down). A no-op if nothing was
+     * held. */
+    gpio_deep_sleep_hold_dis();
+
     /* Master peripheral-rail latch. Must be driven HIGH before any
      * SPI/display/SD bring-up -- without it, the e-paper panel rail
      * and the SD slot both stay unpowered. No I2C expander involved
@@ -1344,6 +1354,33 @@ extern "C" void app_main(void)
         g.pin_bit_mask = (1ULL << XTEINK_POWER_LATCH_PIN);
         gpio_config(&g);
         gpio_set_level((gpio_num_t)XTEINK_POWER_LATCH_PIN, 1);
+    }
+
+    /* Power-CYCLE the GT911 touch controller (active-low enable on
+     * TOUCH_POWER_EN_PIN) -- do it HERE, before the shared I2C bus is
+     * created below, not just before touchscreen_init().
+     *
+     * On a cold boot the GT911 starts unpowered and on a deep-sleep
+     * wake it was gracefully put to sleep first, so both come up clean.
+     * But on a warm reboot -- esp_restart() from the Settings "restart
+     * to apply" prompt (display orientation / margins), a panic or a
+     * watchdog -- esp_restart() does NOT reset the I2C peripheral or
+     * the GT911, which is typically mid-transaction when the SoC
+     * resets. The GT911 is then left holding SDA, every probe on the
+     * shared bus fails, and touch never comes up (the RST pulse in
+     * touchscreen_init() alone does not clear it). Dropping VDD for
+     * 20 ms forces a real power-on reset and releases the bus. GT911
+     * datasheet: >=10 ms unpowered, then ~50 ms to boot before I2C. */
+    {
+        gpio_config_t g = {};
+        g.intr_type    = GPIO_INTR_DISABLE;
+        g.mode         = GPIO_MODE_OUTPUT;
+        g.pin_bit_mask = (1ULL << TOUCH_POWER_EN_PIN);
+        gpio_config(&g);
+        gpio_set_level((gpio_num_t)TOUCH_POWER_EN_PIN, 1);   /* VDD off */
+        vTaskDelay(pdMS_TO_TICKS(20));
+        gpio_set_level((gpio_num_t)TOUCH_POWER_EN_PIN, 0);   /* VDD on  */
+        vTaskDelay(pdMS_TO_TICKS(60));
     }
 #endif
 #if defined(CONFIG_DRAFTLING_DISPLAY_EPDIY) || defined(CONFIG_DRAFTLING_DISPLAY_H752_EPD) || \
@@ -2204,19 +2241,10 @@ extern "C" void app_main(void)
      * tcfg.i2c_bus; on every other board tcfg.i2c_bus stays NULL
      * and the component creates its own bus from sda/scl as before. */
     ESP_LOGI(TAG, "Initializing touchscreen...");
-#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO)
-    /* GT911 power-enable, active-low. Drive it before touch bring-up;
-     * there is no touchscreen_config_t field for this, so it is a
-     * one-off poke here (same style as the SD power-enable above). */
-    {
-        gpio_config_t touch_pwr = {};
-        touch_pwr.intr_type    = GPIO_INTR_DISABLE;
-        touch_pwr.mode         = GPIO_MODE_OUTPUT;
-        touch_pwr.pin_bit_mask = (1ULL << TOUCH_POWER_EN_PIN);
-        gpio_config(&touch_pwr);
-        gpio_set_level((gpio_num_t)TOUCH_POWER_EN_PIN, 0);
-    }
-#endif
+    /* Note: on the Xteink X4 Pro the GT911 power-enable (active-low)
+     * was already configured and power-cycled far above, before the
+     * shared I2C bus was created -- see the comment there. It stays
+     * driven LOW (VDD on) from that point, so nothing to do here. */
     {
         touchscreen_config_t tcfg = {};
         tcfg.sda      = I2C_SDA_PIN;

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -1356,31 +1356,63 @@ extern "C" void app_main(void)
         gpio_set_level((gpio_num_t)XTEINK_POWER_LATCH_PIN, 1);
     }
 
-    /* Power-CYCLE the GT911 touch controller (active-low enable on
-     * TOUCH_POWER_EN_PIN) -- do it HERE, before the shared I2C bus is
-     * created below, not just before touchscreen_init().
+    /* Full GT911 power-cycle + hardware reset with the datasheet
+     * address-select timing. Done HERE, before the shared I2C bus is
+     * created below, and `tcfg.rst` is passed as -1 so touchscreen_init()
+     * does not re-pulse RST and undo the address select.
      *
-     * On a cold boot the GT911 starts unpowered and on a deep-sleep
-     * wake it was gracefully put to sleep first, so both come up clean.
-     * But on a warm reboot -- esp_restart() from the Settings "restart
-     * to apply" prompt (display orientation / margins), a panic or a
-     * watchdog -- esp_restart() does NOT reset the I2C peripheral or
-     * the GT911, which is typically mid-transaction when the SoC
-     * resets. The GT911 is then left holding SDA, every probe on the
-     * shared bus fails, and touch never comes up (the RST pulse in
-     * touchscreen_init() alone does not clear it). Dropping VDD for
-     * 20 ms forces a real power-on reset and releases the bus. GT911
-     * datasheet: >=10 ms unpowered, then ~50 ms to boot before I2C. */
+     * Why the full sequence and not just "enable the rail": on a cold
+     * boot the GT911 has never run, so even a sloppy reset works. But
+     * after a warm reboot -- esp_restart() from the Settings "restart to
+     * apply" prompt (display orientation / margins), a panic, a
+     * watchdog -- esp_restart() does not reset the GT911, and it comes
+     * back either wedged or (observed) answering at its fallback address
+     * 0x14 without ever scanning. The chip only latches a valid config
+     * and starts scanning if INT is held at the address-select level
+     * across the RST rising edge and for T3/T4 afterwards (GT911
+     * datasheet section 5). VDD is dropped first so the reset starts
+     * from a true power-off state regardless of what the chip was doing.
+     *
+     * TOUCH_POWER_EN_PIN is active-low (LOW = VDD on). INT held HIGH
+     * across RST-high selects the primary I2C address 0x5D. */
     {
         gpio_config_t g = {};
         g.intr_type    = GPIO_INTR_DISABLE;
         g.mode         = GPIO_MODE_OUTPUT;
-        g.pin_bit_mask = (1ULL << TOUCH_POWER_EN_PIN);
+        g.pin_bit_mask = (1ULL << TOUCH_POWER_EN_PIN) |
+                         (1ULL << TOUCH_RST_PIN) |
+                         (1ULL << TOUCH_INT_PIN);
         gpio_config(&g);
+
+        gpio_set_level((gpio_num_t)TOUCH_RST_PIN, 0);        /* assert reset */
+        gpio_set_level((gpio_num_t)TOUCH_INT_PIN, 0);
         gpio_set_level((gpio_num_t)TOUCH_POWER_EN_PIN, 1);   /* VDD off */
-        vTaskDelay(pdMS_TO_TICKS(20));
-        gpio_set_level((gpio_num_t)TOUCH_POWER_EN_PIN, 0);   /* VDD on  */
-        vTaskDelay(pdMS_TO_TICKS(60));
+        vTaskDelay(pdMS_TO_TICKS(100));                      /* drain rail fully */
+
+        gpio_set_level((gpio_num_t)TOUCH_POWER_EN_PIN, 0);   /* VDD on */
+        vTaskDelay(pdMS_TO_TICKS(12));                       /* T1: >=10 ms held in reset */
+
+        gpio_set_level((gpio_num_t)TOUCH_INT_PIN, 1);        /* address select -> 0x5D */
+        vTaskDelay(pdMS_TO_TICKS(1));                        /* T2: >100 us */
+
+        gpio_set_level((gpio_num_t)TOUCH_RST_PIN, 1);        /* release reset */
+        vTaskDelay(pdMS_TO_TICKS(8));                        /* T3: hold INT >=5 ms */
+        gpio_set_level((gpio_num_t)TOUCH_INT_PIN, 0);
+        vTaskDelay(pdMS_TO_TICKS(55));                       /* T4: >=50 ms before INT is an input */
+
+        /* INT -> input + pull-up (its normal "data ready" role).
+         * touchscreen_init() also does this; doing it now keeps the
+         * line from floating during the shared-bus + display bring-up
+         * that runs before touchscreen_init(). */
+        gpio_config_t gi = {};
+        gi.intr_type    = GPIO_INTR_DISABLE;
+        gi.mode         = GPIO_MODE_INPUT;
+        gi.pin_bit_mask = (1ULL << TOUCH_INT_PIN);
+        gi.pull_up_en   = GPIO_PULLUP_ENABLE;
+        gpio_config(&gi);
+
+        ESP_LOGI(TAG, "GT911 power-cycled + reset (RST=%d INT=%d, selecting 0x5D)",
+                 TOUCH_RST_PIN, TOUCH_INT_PIN);
     }
 #endif
 #if defined(CONFIG_DRAFTLING_DISPLAY_EPDIY) || defined(CONFIG_DRAFTLING_DISPLAY_H752_EPD) || \
@@ -2241,15 +2273,21 @@ extern "C" void app_main(void)
      * tcfg.i2c_bus; on every other board tcfg.i2c_bus stays NULL
      * and the component creates its own bus from sda/scl as before. */
     ESP_LOGI(TAG, "Initializing touchscreen...");
-    /* Note: on the Xteink X4 Pro the GT911 power-enable (active-low)
-     * was already configured and power-cycled far above, before the
-     * shared I2C bus was created -- see the comment there. It stays
-     * driven LOW (VDD on) from that point, so nothing to do here. */
+    /* Note: on the Xteink X4 Pro the GT911 was fully power-cycled and
+     * hardware-reset (with the datasheet address-select timing) far
+     * above, before the shared I2C bus was created -- see the comment
+     * there. TOUCH_POWER_EN_PIN stays LOW (VDD on) from that point;
+     * tcfg.rst is passed as -1 below so touchscreen_init() does not
+     * re-pulse RST and undo the address select. */
     {
         touchscreen_config_t tcfg = {};
         tcfg.sda      = I2C_SDA_PIN;
         tcfg.scl      = I2C_SCL_PIN;
+#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO)
+        tcfg.rst      = -1;               /* reset already done in the block above */
+#else
         tcfg.rst      = TOUCH_RST_PIN;
+#endif
         tcfg.intr     = TOUCH_INT_PIN;
         tcfg.i2c_addr = TOUCH_I2C_ADDR;
         tcfg.i2c_port = 0;

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -207,21 +207,27 @@ static void pre_sleep_autosave(void)
      *
      * Take the LVGL mutex first so this does not race with the LVGL
      * task's flush_cb. */
-    /* Take the LVGL mutex if we can so the wipe does not race with
-     * the LVGL task's flush_cb. The mutex is recursive
-     * (draftling_lvgl_port_init), so this also works when pre_sleep_autosave
-     * runs inside the LVGL task itself (the "Sleep now" menu path).
-     * If for any reason the lock cannot be obtained quickly, wipe
-     * anyway -- a clean white frame on the panel matters more than
-     * the slim chance of a flush_cb collision right before deep
-     * sleep. */
-    bool locked = draftling_lvgl_port_lock(200);
+    /* Take the LVGL mutex so the wipe does not race with the LVGL
+     * task's flush_cb -- the e-paper backends have no internal lock, so
+     * a concurrent display_full_refresh() here and a flush_cb push from
+     * the LVGL task corrupt the panel's SPI transaction / dirty-rect
+     * state (symptom: the device appears to hang instead of sleeping).
+     * The mutex is recursive (draftling_lvgl_port_init), so this also
+     * works when pre_sleep_autosave runs inside the LVGL task itself
+     * (the "Sleep now" menu path). Wait generously: a single flush is
+     * at most a full-screen e-paper refresh (~2 s), and this path is
+     * followed immediately by deep sleep, so a few extra seconds cost
+     * nothing. A longer wait matters most in the rotated (portrait)
+     * flush path, which is slower than the unrotated one. Only wipe
+     * without the lock if the LVGL task is genuinely wedged. */
+    bool locked = draftling_lvgl_port_lock(5000);
     display_clear(0xFF);
     display_full_refresh();
     if (locked) {
         draftling_lvgl_port_unlock();
     } else {
-        ESP_LOGW(TAG, "pre_sleep wipe: LVGL lock not acquired, proceeded anyway");
+        ESP_LOGW(TAG, "pre_sleep wipe: LVGL lock not acquired in 5 s, "
+                      "proceeded anyway");
     }
 #endif
 }

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -1285,6 +1285,14 @@ extern "C" void app_main(void)
      * boot. */
     display_margins_init();
 
+    /* Load the user-selected display orientation (Settings -> Display
+     * orientation; landscape on a fresh install) before anything below
+     * derives DISPLAY_ROTATE_EFFECTIVE from it. Portrait adds another
+     * 90 degrees on top of the board's build-time base rotation, so
+     * the LVGL rotation angle, the editor's SCR_W / SCR_H, and the
+     * split-screen axis all have to see the same value for the session. */
+    display_orientation_init();
+
 #if defined(CONFIG_DRAFTLING_HAS_POWER_LATCH)
     /* Close the hardware power latch first thing after NVS so the
      * battery rail stays alive when the user releases the boot-time
@@ -1638,11 +1646,17 @@ extern "C" void app_main(void)
     /* Initialize LVGL.
      *
      * LVGL renders 1:1 at the panel resolution; DISPLAY_LOGICAL_WIDTH /
-     * DISPLAY_LOGICAL_HEIGHT are aliases of the physical panel size.
-     * (High-density boards no longer upscale the framebuffer; they use
-     * a larger font instead -- see CONFIG_DRAFTLING_DISPLAY_HIDPI.) */
+     * DISPLAY_LOGICAL_HEIGHT are aliases of the physical panel size
+     * (before rotation -- LVGL swaps them internally for a 90/270
+     * angle). (High-density boards no longer upscale the framebuffer;
+     * they use a larger font instead -- see
+     * CONFIG_DRAFTLING_DISPLAY_HIDPI.)
+     *
+     * DISPLAY_ROTATE_EFFECTIVE folds in the "Display orientation"
+     * setting: portrait = the board's base rotation + 90. */
     ESP_LOGI(TAG, "Initializing LVGL...");
-    draftling_lvgl_port_init(DISPLAY_LOGICAL_WIDTH, DISPLAY_LOGICAL_HEIGHT, DISPLAY_ROTATE);
+    draftling_lvgl_port_init(DISPLAY_LOGICAL_WIDTH, DISPLAY_LOGICAL_HEIGHT,
+                             DISPLAY_ROTATE_EFFECTIVE);
 
     /* Initialize battery voltage monitor before the UI so the editor
      * status bar can show the battery level immediately. battery_init


### PR DESCRIPTION
## What

Adds a **portrait / landscape** display orientation setting.

- New **F1 -> Settings -> "Display orientation: Landscape / Portrait
  (restart to apply)"** row.
- Portrait turns the whole UI another 90 degrees (on top of the board's
  build-time base rotation).
- Frozen for the session like the screen margins, so it only applies
  after a restart -- the editor offers one on the way out of Settings.
  The old margin-change prompt is generalised to **"Restart now to
  apply changes"** and now covers both margins and orientation.
- **Split-screen follows the display's long axis**: left/right panes in
  landscape, **top/bottom panes in portrait**. `Ctrl+3`'s "first pane
  2/3 / 1/3" means top in portrait.

## How

The firmware already had a full software-rotation pipeline in
`lvgl_port.cpp` (used today by the Freenove boards at base 90 and the
Tab5 at base 270). Portrait just feeds it another 90 degrees:

| Piece | Change |
|---|---|
| `components/display/display_orientation.{h,cpp}` | new runtime, NVS-persisted (`disporient` namespace), frozen-at-boot flag -- a direct copy of the `display_margins` pattern |
| `main.cpp` | calls `display_orientation_init()` right after `display_margins_init()` |
| `app_config.h` | `DISPLAY_ROTATE_EFFECTIVE` = base rotation `+ 90` (mod 360) in portrait; handed to `draftling_lvgl_port_init()` |
| `editor_ui.cpp` | `scr_axes_swapped()` XORs build-base and portrait to pick `SCR_W`/`SCR_H`; `recalc_pane_geometry()` / `layout_panes()` split top/bottom in portrait; `MAX_LINE_LABELS` 24 -> 40 so the taller portrait body isn't left half-empty on small panels |

The **display backends are untouched** -- they only ever see physical
panel coordinates; LVGL swaps its reported resolution and `flush_cb`
rotates each tile. The **touchscreen config is untouched** too: LVGL
rotates indev points itself via `lv_display_rotate_point()` (verified
in the vendored LVGL source), the exact path the Tab5 already relies
on.

## Testing

`idf.py build` passes for a spread of backends:
`xteink_x4_pro` (SPI e-paper, HIDPI, base 0), `freenove_fnk0104b`
(colour SPI + touch, base 90), `waveshare_rlcd42` (reflective LCD, FULL
render mode, CAN_INVERT), `sunton_8048s043` (parallel RGB, HIDPI,
CAN_ROTATE).

**Not yet exercised on hardware.** Portrait would be the first time an
e-paper backend runs the 90/270 tile-rotation + partial-refresh path,
and the first hardware check of the LVGL indev rotation at an angle
other than the Tab5's 270 -- both want a real-device pass before this
is relied on.

## Notes

- Screen-margin semantics in portrait match the existing base-90/270
  boards (the margin pair that spans the physical vertical axis is
  subtracted from `SCR_W`); a user may want to retune margins after
  changing orientation.
- Very large panels (Tab5, 7" Sunton) still cap the visible line count
  in portrait, the same way they already do in landscape.
- Also folds two stray `### Changed` CHANGELOG headers (a merge
  artifact from #53/#54) back into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Follow-up commit (ee0c816)

**Xteink X4 Pro portrait turns the other way.** New non-prompted Kconfig
int `DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE` = degrees added on top of
the base rotation for portrait (default **90**, **270** for the X4
Pro). `DISPLAY_ROTATE_EFFECTIVE` uses it in place of a hard-coded `+90`.
`scr_axes_swapped()` is unaffected -- 90 and 270 are both quarter
turns.

**`Ctrl+P` and `Ctrl+1` / `Ctrl+2` / `Ctrl+3` now work in the file
browser too.** `handle_browser_key()`: `Ctrl+P` → `standby_enter_sleep()`
(no editor screen to prompt on; pre-sleep auto-save covers any open
doc); `Ctrl+1/2/3` update `s_split_mode` + NVS and show a status line,
and the layout materialises on the next file open (`browser_activate_item`
already had a split branch). The in-pane split-mode selector swallows
`Ctrl+1/2/3` so a mid-pick change can't collapse the overlay it sits on.


---

### Follow-up commits (efc196e, 7c7b169)

Reported after testing on an X4 Pro in portrait:

**Touch input was a quarter turn off** in any 90/270 rotation (the
natively-portrait Freenove FNK0104B/S, and now portrait mode).
`lvgl_port`'s `flush_cb` rotates pixels with a sense *opposite* to
LVGL's `lv_display_rotate_area/point()`, but `lv_display_set_rotation()`
was handed `s_rotate_deg` directly, so LVGL rotated the touch point the
wrong way. New `lvgl_rotation_for_port_deg()` feeds LVGL the mirrored
quarter turn (90↔270; 0/180 unchanged). Resolution swap is identical
for 90/270 and `matrix_rotation` is off, so **display output is
unchanged** — only the touch-point transform, which is now the exact
inverse of the pixel transform.

**Power button "does not sleep" in portrait.** The pre-deep-sleep
e-paper wipe (`display_clear` + `display_full_refresh`, on the esp_timer
task) only waited 200 ms for the LVGL port mutex before proceeding
anyway. The e-paper backends have no internal lock, so a concurrent
wipe + `flush_cb` push corrupts the panel SPI transaction and the
device hangs instead of sleeping. The rotated flush path is slower, so
the 200 ms lapsed mid-flush much more often. Now waits up to 5 s (deep
sleep follows immediately, so the wait is free).

**`Ctrl+1/2/3` in the file browser** now redraw: enabling a split from
the full-screen browser switches to the editor so it's visible right
away, and `Ctrl+1` collapses a split from the in-pane file selector
(the "browser" a split editor shows on Esc), which previously did
nothing.


### Follow-up commit (0c7e455)

**X4 Pro touch dead after the "restart to apply" prompt.** `esp_restart()`
does not reset the I2C peripheral or the GT911, and the controller is
usually mid-transaction when the SoC resets, so it's left holding SDA
and every probe on the shared bus fails. (Cold boot / deep-sleep wake
avoid it because the GT911 was unpowered or gracefully slept.) Now
`app_main()` power-cycles the GT911 via its active-low
`TOUCH_POWER_EN_PIN` *before* the shared I2C bus is created, and calls
`gpio_deep_sleep_hold_dis()` first so the deep-sleep GPIO hold can't pin
that pin.
