### PR TITLE
Add support for Xteink X4 Classic (X4 v2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ card).
 | Freenove FNK0104B | 2.8-inch ILI9341 color LCD, 320x240, FT6336U touch |
 | Freenove FNK0104S | 4.0-inch ST7796 color LCD, 480x320, FT6336U touch |
 | Xteink X4 Pro | 4.26-inch e-paper (SSD1677/UC8179/UC8279, auto-detected), 800x480, GT911 touch |
+| Xteink X4 Classic (X4 v2) | 4.26-inch e-paper (SSD1677/UC8179/UC8279, auto-detected), 800x480, no touch, no front-light |
 | Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI | 5.79-inch e-paper (SSD1683 x2), 792x272, no touch |
 
 UC8179-based panels (Seeed Studio reTerminal E1001 and the Waveshare
@@ -94,11 +95,13 @@ CMakeLists.txt              Top-level CMake project file
 CMakePresets.json           Per-board build presets (idf.py --preset <board>)
 partitions.csv              Custom partition table (16 MB flash, single
                             "factory" app) -- used by every board except
-                            the two below
+                            the three below
 partitions_8mb.csv          8 MB-flash variant (Elecrow CrowPanel 5.79")
 partitions_xteink_x4_pro.csv Dual-OTA layout (otadata + ota_0/ota_1) so
                             the Xteink X4 Pro can be re-flashed with the
                             stock or Crosspoint firmware afterwards
+partitions_xteink_x4_classic.csv  Same dual-OTA layout for the Xteink
+                            X4 Classic (X4 v2)
 sdkconfig.defaults          Common Kconfig defaults for all targets
 sdkconfig.defaults.esp32s3  ESP32-S3-specific defaults (PSRAM, BLE, WiFi)
 sdkconfig.defaults.<board>  Per-board target + hardware-model defaults, one
@@ -188,8 +191,9 @@ Two backends:
   the IP2326 charger pushes positive current into the cell). See
   `docs/tab5-esp-hosted.md` for the CHG_EN enable path.
 * **CellWise CW2017 fuel gauge** over I2C
-  (`battery_init_cw2017(bus)`): used on the Xteink X4 Pro, at 0x63 on
-  the I2C bus shared with GT911 touch. Unlike BQ27220, the CW2017's
+  (`battery_init_cw2017(bus)`): used on the Xteink X4 Pro and X4
+  Classic, at 0x63 on the I2C bus (shared with GT911 touch on the X4
+  Pro). Unlike BQ27220, the CW2017's
   SOC register (0x04) reports a direct integer percentage -- no
   voltage-to-percent LUT needed -- but only once a matching 80-byte
   "BATINFO" battery profile is resident; `battery_init_cw2017()`
@@ -306,7 +310,12 @@ Per-board display backends behind a single C API:
   raced with the async DMA hardware, corrupting the lower portion of
   the screen once the transaction queue filled up.
 - **display_xteink_epd.cpp** -- from-scratch SPI e-paper backend for
-  the Xteink X4 Pro, gated on `CONFIG_DRAFTLING_DISPLAY_XTEINK_EPD`.
+  the Xteink X4 Pro and X4 Classic, gated on
+  `CONFIG_DRAFTLING_DISPLAY_XTEINK_EPD`. The two boards share the
+  controller code and differ only in the DC/RST/BUSY pin set and
+  whether the front-light code compiles in -- both switched at build
+  time on `CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC` /
+  `CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT`.
   Unlike the other e-paper backends this board carries one of three
   possible panel controllers depending on manufacturing run (SSD1677,
   or one of two UltraChip parts, UC8179 / UC8279); `display_init()`
@@ -1070,6 +1079,19 @@ ESP32-S3-only (`depends on IDF_TARGET_ESP32S3`):
   touch is dead until the next deep-sleep cycle. Tested on physical
   hardware after an initial blind port; see HARDWARE.md.
   *Requires ESP32-S3.*
+- **DRAFTLING_MODEL_XTEINK_X4_CLASSIC** -- Xteink X4 Classic (a.k.a.
+  "X4 v2"): the buttons-only, no-front-light sibling of the X4 Pro.
+  Same ESP32-S3, same 800x480 panel and `display_xteink_epd.cpp`
+  controller stack (DC/RST/BUSY on 14/10/18 instead of 18/14/6), same
+  CW2017 gauge and SDMMC slot. `CONFIG_DRAFTLING_TOUCHSCREEN` and
+  `CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT` are both off. Eight buttons
+  (`xteink_x4_classic_btn_init()` in `main.cpp`) drive the editor with
+  no keyboard, the same buttons-only model as the CrowPanel: Power
+  (GPIO3) = F1 / forget-keyboards, side keys = Up/Down, bottom keys =
+  Left/Right/Enter/Esc. The derived symbol `DRAFTLING_MODEL_XTEINK_X4`
+  is set for both this and the X4 Pro and gates the code common to
+  the two. Added without on-hardware testing (pin map from the FreeInk
+  SDK); see HARDWARE.md. *Requires ESP32-S3.*
 - **DRAFTLING_MODEL_ELECROW_CROWPANEL_579** -- Elecrow CrowPanel
   ESP32-S3 5.79" E-Paper HMI Display: 792x272 black/white e-paper
   panel built from two SSD1683 controllers over plain SPI, driven by
@@ -1084,11 +1106,11 @@ The hardware-model selection drives two non-prompted `int` symbols
 consumed in `main/app_config.h` as `DISPLAY_WIDTH` / `DISPLAY_HEIGHT`:
 
 - **DRAFTLING_DISPLAY_WIDTH** -- 400 (RLCD), 960 (PaperS3), 320
-  (FNK0104A/B), 480 (FNK0104S), 800 (Xteink X4 Pro), 792 (Elecrow
-  CrowPanel 5.79").
+  (FNK0104A/B), 480 (FNK0104S), 800 (Xteink X4 Pro / X4 Classic), 792
+  (Elecrow CrowPanel 5.79").
 - **DRAFTLING_DISPLAY_HEIGHT** -- 300 (RLCD), 540 (PaperS3), 240
-  (FNK0104A/B), 320 (FNK0104S), 480 (Xteink X4 Pro), 272 (Elecrow
-  CrowPanel 5.79").
+  (FNK0104A/B), 320 (FNK0104S), 480 (Xteink X4 Pro / X4 Classic), 272
+  (Elecrow CrowPanel 5.79").
 
 ### Screen margins (user-adjustable, not a Kconfig setting)
 
@@ -1149,8 +1171,9 @@ CONFIG_DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE` (mod 360) in portrait,
 and that is what `main.cpp` passes to `draftling_lvgl_port_init()`.
 `DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE` is a non-prompted derived
 `int` (Kconfig.projbuild) defaulting to **90**; the **Xteink X4 Pro**
-sets it to **270** because that board's enclosure reads better with
-portrait turned the opposite way. LVGL then swaps its own reported
+and **X4 Classic** set it to **270** because that board family's
+enclosure reads better with portrait turned the opposite way. LVGL
+then swaps its own reported
 resolution, and `flush_cb` software-rotates each tile back to physical
 panel coordinates -- the display backends stay rotation-agnostic.
 `DISPLAY_LOGICAL_WIDTH/HEIGHT` and the touchscreen `logical_width/height`
@@ -1196,10 +1219,11 @@ in C / C++ code:
 | Symbol | Purpose | Set by |
 |--------|---------|--------|
 | DRAFTLING_DISPLAY_RLCD            | Selects `display_rlcd.cpp`        | RLCD-4.2 |
-| DRAFTLING_DISPLAY_EPD             | Gates EPD-only options (BLACK_BACKGROUND, full-refresh interval) and the editor's no-blink cursor / 120 ms flush debounce | PaperS3, LilyGO T5 E-Paper S3 Pro / Pro Lite, Xteink X4 Pro, Elecrow CrowPanel 5.79" |
+| DRAFTLING_MODEL_XTEINK_X4         | Common to the Xteink X4 Pro and X4 Classic (shared `display_xteink_epd.cpp` backend, CW2017 gauge, SDMMC slot, OTA partition table, GPIO1 peripheral-rail latch, GPIO3 Power/wake) | Xteink X4 Pro, Xteink X4 Classic |
+| DRAFTLING_DISPLAY_EPD             | Gates EPD-only options (BLACK_BACKGROUND, full-refresh interval) and the editor's no-blink cursor / 120 ms flush debounce | PaperS3, LilyGO T5 E-Paper S3 Pro / Pro Lite, Xteink X4 Pro / X4 Classic, Elecrow CrowPanel 5.79" |
 | DRAFTLING_DISPLAY_EPDIY           | Selects `display_epdiy.cpp` (with `epd_board_v7` for LilyGO T5 or the in-tree `epd_board_papers3` for PaperS3) and pulls in the `vroland/epdiy` managed component | PaperS3, LilyGO T5 E-Paper S3 Pro / Pro Lite |
 | DRAFTLING_EPDIY_BOARD_PAPERS3     | Switches `display_epdiy.cpp` to the PaperS3 board definition (no VCOM, no shared I2C) | PaperS3 |
-| DRAFTLING_DISPLAY_XTEINK_EPD      | Selects `display_xteink_epd.cpp` (plain SPI, auto-detects SSD1677/UC8179/UC8279 at boot) | Xteink X4 Pro |
+| DRAFTLING_DISPLAY_XTEINK_EPD      | Selects `display_xteink_epd.cpp` (plain SPI, auto-detects SSD1677/UC8179/UC8279 at boot) | Xteink X4 Pro, Xteink X4 Classic |
 | DRAFTLING_DISPLAY_SSD1683         | Selects `display_ssd1683.cpp` (dual-controller plain-SPI e-paper backend) | Elecrow CrowPanel 5.79" |
 | DRAFTLING_DISPLAY_AXS15231B       | Selects `display_axs15231b.cpp`   | Touch-LCD-3.49, JC3248W535 |
 | DRAFTLING_DISPLAY_ILI9341         | Selects `display_ili9341.cpp` (shared ILI9341/ST7796 SPI backend) with the ILI9341 init sequence | Freenove FNK0104A / FNK0104B |
@@ -1210,12 +1234,12 @@ in C / C++ code:
 | DRAFTLING_DISPLAY_COLOR           | Enables the color-theme picker; PARTIAL render mode in `lvgl_port.cpp` | AXS15231B boards, Tab5, RGB boards, Freenove FNK0104 family |
 | DRAFTLING_DISPLAY_HAS_BACKLIGHT   | Adds the "Backlight: NN%" entry to F1 -> Settings, enables the Ctrl+B cycle shortcut, and calls `display_set_backlight()` at boot from NVS -- unless DRAFTLING_DISPLAY_BACKLIGHT_BINARY is also set (see below) | AXS15231B boards, Tab5, LilyGO T5 E-Paper S3 Pro / Pro Lite, RGB boards, Freenove FNK0104 family |
 | DRAFTLING_DISPLAY_BACKLIGHT_BINARY | Suppresses the entire backlight Settings entry / Ctrl+B feature (no PWM dimming is physically possible, so a brightness control would be misleading); the backlight is left at the display backend's own default (on) | Waveshare Touch-LCD-7 (any CH422G board) |
-| DRAFTLING_DISPLAY_HIDPI           | Renders the UI 1:1 with the larger Hack font (instead of upscaling the framebuffer); compiles the `hack_*` font sources and selects the Hack family in `editor_ui.cpp` | PaperS3, LilyGO T5 E-Paper S3 Pro / Pro Lite, Tab5, Sunton 8048S070 / 8048S043, Waveshare Touch-LCD-7, Xteink X4 Pro |
-| DRAFTLING_HAS_BATTERY             | Creates the battery-percentage status-bar label and its poll timer | RLCD-4.2, PaperS3, Touch-LCD-3.49, T5 E-Paper S3 Pro / Pro Lite, Freenove FNK0104 family, Xteink X4 Pro |
+| DRAFTLING_DISPLAY_HIDPI           | Renders the UI 1:1 with the larger Hack font (instead of upscaling the framebuffer); compiles the `hack_*` font sources and selects the Hack family in `editor_ui.cpp` | PaperS3, LilyGO T5 E-Paper S3 Pro / Pro Lite, Tab5, Sunton 8048S070 / 8048S043, Waveshare Touch-LCD-7, Xteink X4 Pro / X4 Classic |
+| DRAFTLING_HAS_BATTERY             | Creates the battery-percentage status-bar label and its poll timer | RLCD-4.2, PaperS3, Touch-LCD-3.49, T5 E-Paper S3 Pro / Pro Lite, Freenove FNK0104 family, Xteink X4 Pro / X4 Classic |
 | DRAFTLING_BATTERY_BQ27220         | Selects the BQ27220 fuel-gauge backend (`battery_init_bq27220(shared_i2c_bus)`) instead of the GPIO ADC backend | T5 E-Paper S3 Pro / Pro Lite |
-| DRAFTLING_BATTERY_CW2017          | Selects the CW2017 fuel-gauge backend (`battery_init_cw2017(shared_i2c_bus)`); no charger IC on the bus, so charging state always reads unknown | Xteink X4 Pro |
+| DRAFTLING_BATTERY_CW2017          | Selects the CW2017 fuel-gauge backend (`battery_init_cw2017(shared_i2c_bus)`); no charger IC on the bus, so charging state always reads unknown | Xteink X4 Pro / X4 Classic |
 | DRAFTLING_HAS_POWER_LATCH         | Enables the `power` component: TCA9554-latched battery rail + PWR-button long-press = power off; standby cuts the latch before falling back to deep sleep | Touch-LCD-3.49 |
-| DRAFTLING_SD_SDMMC                | Routes SD init through the on-chip SDMMC peripheral (1-bit) instead of generic SPI | RLCD-4.2, Freenove FNK0104 family, Xteink X4 Pro |
+| DRAFTLING_SD_SDMMC                | Routes SD init through the on-chip SDMMC peripheral (1-bit) instead of generic SPI | RLCD-4.2, Freenove FNK0104 family, Xteink X4 Pro / X4 Classic |
 | DRAFTLING_WAKEUP_GPIO             | RTC-capable EXT0 wake-up GPIO; consumed by `components/standby/standby.cpp` | per-model defaults |
 | DRAFTLING_TOUCH_FT6336U           | Adds the FT6336U poll routine to `components/touchscreen/touchscreen.cpp` (8-bit register protocol) | Freenove FNK0104B / FNK0104S |
 
@@ -1241,7 +1265,7 @@ The runtime **"Display orientation"** setting (F1 -> Settings; see the
 "Display orientation" section below) adds
 `DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE` degrees on top of this for
 portrait -- a second non-prompted derived `int` in this file, default
-90, set to 270 on the Xteink X4 Pro. `app_config.h`'s
+90, set to 270 on the Xteink X4 Pro / X4 Classic. `app_config.h`'s
 `DISPLAY_ROTATE_EFFECTIVE` is what `main.cpp` actually passes to
 `draftling_lvgl_port_init()`.
 
@@ -1314,7 +1338,8 @@ board (`waveshare_rlcd42`, `m5stack_papers3`, `lilygo_t5_epd_s3_pro`,
 `lilygo_t5_epd_s3_pro_h752`, `waveshare_touch_lcd_349`, `m5stack_tab5`,
 `jc3248w535`, `sunton_8048s070`, `sunton_8048s043`,
 `waveshare_touch_lcd_7`, `freenove_fnk0104a`, `freenove_fnk0104b`,
-`freenove_fnk0104s`, `xteink_x4_pro`, `elecrow_crowpanel_579`). Each
+`freenove_fnk0104s`, `xteink_x4_pro`, `xteink_x4_classic`,
+`elecrow_crowpanel_579`). Each
 preset points `SDKCONFIG_DEFAULTS` at `sdkconfig.defaults` plus its own
 `sdkconfig.defaults.<board>` file (which sets `CONFIG_IDF_TARGET` and
 the board's `CONFIG_DRAFTLING_MODEL_*` option), and places `binaryDir` /
@@ -1385,14 +1410,15 @@ tree referenced in steps 1-4.
    gh release upload vX.Y.Z draftling-<board>-bootloader.bin \
        draftling-<board>-partition-table.bin draftling-<board>.bin
    ```
-   `xteink_x4_pro` also needs a fourth image,
+   `xteink_x4_pro` (and `xteink_x4_classic`) also needs a fourth image,
    `draftling-xteink_x4_pro-otadata.bin` (from
    `firmware/build/xteink_x4_pro/ota_data_initial.bin`): its partition
-   table is dual-OTA (`partitions_xteink_x4_pro.csv`), so a clean flash
-   must also (re)initialise the `otadata` partition at `0xd000` -- an
-   8 KB all-`0xFF` blob that makes the bootloader pick `ota_0`.
-   Otherwise a stale `otadata` left by the stock firmware could point
-   the bootloader at the empty `ota_1`.
+   table is dual-OTA (`partitions_xteink_x4_pro.csv` /
+   `partitions_xteink_x4_classic.csv`), so a clean flash must also
+   (re)initialise the `otadata` partition at `0xd000` -- an 8 KB
+   all-`0xFF` blob that makes the bootloader pick `ota_0`. Otherwise a
+   stale `otadata` left by the stock firmware could point the
+   bootloader at the empty `ota_1`.
 5. Update the web flasher on the `_flasher` branch (see its own
    `README.md` for the full layout and rationale -- it is an orphan
    branch with no shared history with `main`, published via GitHub

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,7 +31,8 @@ Available preset names: `waveshare_rlcd42`, `m5stack_papers3`,
 `lilygo_t5_epd_s3_pro`, `lilygo_t5_epd_s3_pro_h752`,
 `waveshare_touch_lcd_349`, `m5stack_tab5`, `jc3248w535`,
 `sunton_8048s070`, `sunton_8048s043`, `waveshare_touch_lcd_7`,
-`freenove_fnk0104a`, `freenove_fnk0104b`, `freenove_fnk0104s`.
+`freenove_fnk0104a`, `freenove_fnk0104b`, `freenove_fnk0104s`,
+`xteink_x4_pro`, `xteink_x4_classic`, `elecrow_crowpanel_579`.
 
 To avoid repeating `--preset` on every command, set the `IDF_PRESET`
 environment variable instead:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ in the git log.
 
 ## [Unreleased]
 
+### Added
+
+- **Xteink X4 Classic** (also sold as "X4 v2") support: the
+  buttons-only, no-front-light sibling of the X4 Pro. Shares the X4
+  Pro's ESP32-S3, 800x480 e-paper panel (SSD1677 / UC8179 / UC8279,
+  auto-detected), CW2017 fuel gauge and SDMMC card slot. Eight buttons
+  drive the whole editor without a keyboard: Power = F1 / hold to
+  forget keyboards, two side keys = Up/Down, four bottom keys =
+  Left/Right/Enter/Esc. Added without on-hardware testing (pin map
+  from the FreeInk SDK); build it with `idf.py --preset
+  xteink_x4_classic`.
+
 ## [1.0.2] - 2026-09-06
 
 ### Added

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -311,6 +311,43 @@ ESP-IDF two-OTA default) to make room for `otadata` + `phy_init` below
 the 64 KB-aligned `ota_0` offset; re-flashing Draftling onto an X4 Pro
 that already runs it therefore clears the stored BLE pairings once.
 
+## Xteink X4 Classic (X4 v2)
+
+Xteink X4 Classic -- also sold as "X4 v2" -- is the buttons-only
+sibling of the X4 Pro. It uses the same ESP32-S3 module, the same
+4.26" 800x480 e-paper glass and the same auto-detecting SSD1677 /
+UC8179 / UC8279 display backend (`display_xteink_epd.cpp`), the same
+CW2017 I2C fuel gauge and the same SDMMC 1-bit MicroSD slot, so most
+of the X4 Pro notes above apply. The differences Draftling cares
+about:
+
+* **No GT911 touch** and **no front-light** (`CONFIG_DRAFTLING_TOUCHSCREEN`
+  and `CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT` are both off). The GPIOs
+  the X4 Pro spends on touch power-enable (GPIO2) and the warm/cool
+  front-light PWM (GPIO8/GPIO9) are wired to extra front buttons here.
+* **Different panel control pins**: DC=14, RST=10, BUSY=18 (the X4 Pro
+  uses 18/14/6). SCLK=12, MOSI=11, CS=13 are the same, and
+  `display_xteink_epd.cpp` picks the pin set at build time on
+  `CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC`. Its UC8279 init also
+  omits the PLL (0x30) command the X4 Pro programs.
+* **SD power-enable on GPIO6** (GPIO5 on the X4 Pro), power-cycled
+  (HIGH ~80 ms, then held LOW) before mount.
+* **Eight buttons** drive the editor without a keyboard, the same
+  buttons-only model as the CrowPanel 5.79": Power (GPIO3, deep-sleep
+  wake) short-press = F1 / 2 s hold = forget BLE keyboards; two side
+  keys = Up / Down; four bottom keys = Left / Right / Enter / Esc.
+  See `xteink_x4_classic_btn_init()` in `firmware/main/main.cpp`.
+
+Partition table: `firmware/partitions_xteink_x4_classic.csv`, identical
+in layout to the X4 Pro's (dual-OTA, so the stock / Crosspoint OTA
+updaters can reinstall).
+
+**This board has been added without on-hardware testing.** Pin
+assignments come from the [FreeInk SDK](https://github.com/Free-Ink/freeink-sdk)
+(`docs/xteink-x4c-support.md`, MIT licensed), which reverse-engineered
+the OEM firmware. The screen-margin, portrait-rotation and
+grayscale-not-implemented caveats are all as for the X4 Pro.
+
 ## Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI Display
 
 [Elecrow CrowPanel ESP32-S3 5.79" E-Paper HMI

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ load the firmware quickly without having to compile it.
 
 * Ready-made consumer grade hardware
   * Xteink X4 Pro, so far the best value for money amongst e-paper devices.
+  * Xteink X4 Classic (a.k.a. X4 v2) -- the buttons-only, no-front-light X4.
   * LilyGO T5 E-Paper S3 Pro / Pro Lite
   * M5Stack PaperS3 (discontinued)
   * Waveshare ESP32-S3-Touch-LCD-3.49

--- a/firmware/CMakePresets.json
+++ b/firmware/CMakePresets.json
@@ -128,6 +128,15 @@
             }
         },
         {
+            "name": "xteink_x4_classic",
+            "displayName": "Xteink X4 Classic / X4 v2 (SSD1677/UC8179/UC8279, 800x480 e-paper, no touch)",
+            "binaryDir": "build/xteink_x4_classic",
+            "cacheVariables": {
+                "SDKCONFIG_DEFAULTS": "sdkconfig.defaults;sdkconfig.defaults.xteink_x4_classic",
+                "SDKCONFIG": "build/xteink_x4_classic/sdkconfig"
+            }
+        },
+        {
             "name": "elecrow_crowpanel_579",
             "displayName": "Elecrow CrowPanel ESP32-S3 5.79in E-Paper HMI (SSD1683 x2)",
             "binaryDir": "build/elecrow_crowpanel_579",

--- a/firmware/components/display/display_xteink_epd.cpp
+++ b/firmware/components/display/display_xteink_epd.cpp
@@ -2,7 +2,18 @@
 #if defined(CONFIG_DRAFTLING_DISPLAY_XTEINK_EPD)
 
 /*
- * Xteink X4 Pro SPI e-paper backend.
+ * Xteink X4 Pro / X4 Classic SPI e-paper backend.
+ *
+ * Both boards carry the same 4.26" 800x480 e-paper glass and the same
+ * three-controller lottery; they differ only in wiring and trim:
+ *   - X4 Pro:     DC=18, RST=14, BUSY=6, dual-channel front-light on
+ *                 GPIO8/GPIO9.
+ *   - X4 Classic: DC=14, RST=10, BUSY=18, NO front-light (GPIO8/GPIO9
+ *                 are buttons). Its UC8279 init also omits the PLL
+ *                 (0x30) command the X4 Pro programs.
+ * SCLK=12, MOSI=11, CS=13 are common. The pin set and the front-light
+ * code are selected at build time on CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC
+ * / CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT.
  *
  * Different manufacturing runs of this board ship one of three panel
  * controllers -- SSD1677, or one of two UltraChip parts (UC8179 /
@@ -22,10 +33,9 @@
  * Uc8279X4Driver.cpp, EpdBus.cpp and XteinkDetect.cpp). This board has
  * NOT been tested on physical hardware; see HARDWARE.md.
  *
- * Panel: 800x480, no mirror. SPI: SCLK=12, MOSI=11, CS=13, DC=18,
- * RST=14, BUSY=6, no MISO in normal operation (the boot-time probe
- * temporarily reconfigures MOSI as an input for its half-duplex
- * VER/FLG read). Dual-channel (cool/warm) PWM front-light on GPIO8/9.
+ * Panel: 800x480, no mirror. No MISO in normal operation (the
+ * boot-time probe temporarily reconfigures MOSI as an input for its
+ * half-duplex VER/FLG read).
  */
 
 #include <algorithm>
@@ -61,17 +71,25 @@ static const char *TAG = "DisplayXteink";
 #define UC8279_GATE_OFFSET     120
 #define UC81XX_SCRATCH_BYTES   (PANEL_WIDTH_BYTES * UC81XX_TRES_HEIGHT)
 
-/* ---- Pins. This backend is used by exactly one board, so the pins
- * are hard-coded here rather than threaded through a board header --
- * matching display_ili9341.cpp / display_h752.cpp. ---- */
+/* ---- Pins. This backend is used by exactly the two Xteink X4
+ * boards, so the pins are hard-coded here rather than threaded
+ * through a board header -- matching display_ili9341.cpp /
+ * display_h752.cpp -- and the small per-board delta is a build-time
+ * switch on the model symbol. ---- */
 #define EPD_SCLK_PIN         12
 #define EPD_MOSI_PIN         11
 #define EPD_CS_PIN           13
+#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
+#define EPD_DC_PIN           14
+#define EPD_RST_PIN          10
+#define EPD_BUSY_PIN         18
+#else
 #define EPD_DC_PIN           18
 #define EPD_RST_PIN          14
 #define EPD_BUSY_PIN         6
 #define FRONTLIGHT_COOL_PIN  8
 #define FRONTLIGHT_WARM_PIN  9
+#endif
 
 #define XTEINK_SPI_HOST      SPI2_HOST
 /* The OEM firmware clocks this panel at 5 MHz. The SSD1677 is rated
@@ -101,8 +119,10 @@ static const char *TAG = "DisplayXteink";
 #define XTEINK_FULL_REFRESH_INTERVAL 30
 #endif
 
-/* Front-light LEDC: two channels driven identically (Draftling has no
- * warm/cool color-temperature UI), 10 kHz / 10-bit, active-HIGH. */
+/* Front-light LEDC (X4 Pro only -- the X4 Classic has none): two
+ * channels driven identically (Draftling has no warm/cool
+ * color-temperature UI), 10 kHz / 10-bit, active-HIGH. */
+#if defined(CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT)
 #define BL_LEDC_TIMER        LEDC_TIMER_0
 #define BL_LEDC_MODE         LEDC_LOW_SPEED_MODE
 #define BL_LEDC_CHANNEL_COOL LEDC_CHANNEL_0
@@ -110,6 +130,7 @@ static const char *TAG = "DisplayXteink";
 #define BL_LEDC_DUTY_RES     LEDC_TIMER_10_BIT
 #define BL_LEDC_DUTY_MAX     ((1 << 10) - 1)
 #define BL_LEDC_FREQ_HZ      10000
+#endif
 
 enum xteink_ctrl_t {
     XTEINK_CTRL_SSD1677 = 0,
@@ -122,7 +143,9 @@ static uint8_t  *s_fb = NULL;
 static uint8_t  *s_scratch = NULL;   /* UC8179/UC8279 padded/reversed staging buffer */
 static uint8_t  *s_white_scratch = NULL; /* constant all-white OLD-plane buffer, see uc8179/uc8279_display_full() */
 static bool      s_initialized = false;
+#if defined(CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT)
 static bool      s_bl_inited = false;
+#endif
 static bool      s_needs_initial_full = true;
 static bool      s_force_full = true;
 static int       s_partial_count = 0;
@@ -626,7 +649,11 @@ static void uc8279_init(void)
     epd_cmd(0x65); epd_data1(0); epd_data1(0); epd_data1(0); epd_data1(0); /* GATE_SOURCE_START */
 
     epd_cmd(0x03); epd_data1(0x20); /* PFS */
-    epd_cmd(0x30); epd_data1(0x0E); /* PLL */
+#if !defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
+    epd_cmd(0x30); epd_data1(0x0E); /* PLL -- X4 Pro only; the X4
+                                    * Classic OEM init omits it
+                                    * (FreeInk SDK xteink-x4c doc) */
+#endif
     epd_cmd(0xE1); epd_data1(0x02); /* GATE_SCAN */
 
     s_uc81xx_screen_on = false;
@@ -736,6 +763,8 @@ static void ctrl_deep_sleep(void)
 
 /* ---- Front-light (dual-channel PWM) ---- */
 
+#if defined(CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT)
+
 static void backlight_pwm_init(void)
 {
     if (s_bl_inited) return;
@@ -780,6 +809,17 @@ extern "C" void display_set_backlight(int percent)
     ESP_ERROR_CHECK(ledc_set_duty(BL_LEDC_MODE, BL_LEDC_CHANNEL_WARM, duty));
     ESP_ERROR_CHECK(ledc_update_duty(BL_LEDC_MODE, BL_LEDC_CHANNEL_WARM));
 }
+
+#else  /* !CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT -- Xteink X4 Classic */
+
+static inline void backlight_pwm_init(void) {}
+
+/* No front-light on this board. Kept as a no-op so the editor's
+ * Ctrl+B / Settings path links even though its callers are compiled
+ * out (matches display_ssd1683.cpp). */
+extern "C" void display_set_backlight(int /*percent*/) {}
+
+#endif /* CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT */
 
 /* ---- display.h public API ---- */
 
@@ -866,7 +906,7 @@ extern "C" void display_init(int, int, int, int, int, int, int width, int height
     clear_dirty();
     s_initialized = true;
 
-    ESP_LOGI(TAG, "Xteink X4 Pro e-paper initialized (%dx%d, controller=%d)",
+    ESP_LOGI(TAG, "Xteink X4 e-paper initialized (%dx%d, controller=%d)",
              s_width, s_height, (int)s_ctrl);
 }
 
@@ -993,6 +1033,7 @@ extern "C" void display_wake(void)
 
 extern "C" void display_deep_sleep_prepare(void)
 {
+#if defined(CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT)
     if (s_bl_inited) {
         ledc_set_duty(BL_LEDC_MODE, BL_LEDC_CHANNEL_COOL, 0);
         ledc_update_duty(BL_LEDC_MODE, BL_LEDC_CHANNEL_COOL);
@@ -1006,6 +1047,7 @@ extern "C" void display_deep_sleep_prepare(void)
         gpio_set_level((gpio_num_t)pin, 0);
         gpio_hold_en((gpio_num_t)pin);
     }
+#endif
 
     if (s_initialized) ctrl_deep_sleep();
     s_initialized = false;

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -181,6 +181,31 @@ config DRAFTLING_MODEL_XTEINK_X4_PRO
         used here on real units. Grayscale / anti-aliasing rendering
         is not implemented (matches the existing e-paper boards).
 
+config DRAFTLING_MODEL_XTEINK_X4_CLASSIC
+    bool "Xteink X4 Classic / X4 v2 (ESP32-S3, SSD1677/UC8179/UC8279, 4.26\" e-paper, 800x480, no touch)"
+    depends on IDF_TARGET_ESP32S3
+    help
+        Xteink X4 Classic e-reader (also marketed "X4 v2"): the
+        buttons-only sibling of the Xteink X4 Pro. Same ESP32-S3
+        module, same 4.26" 800x480 e-paper glass and the same
+        auto-detecting SSD1677 / UC8179 / UC8279 display backend
+        (components/display/display_xteink_epd.cpp), same CW2017 I2C
+        fuel gauge and SDMMC 1-bit MicroSD -- but no GT911 touch and
+        no front-light. The panel's DC/RST/BUSY lines land on
+        different GPIOs than the X4 Pro (SCLK/MOSI/CS are the same).
+
+        Eight buttons drive the editor without a keyboard: Power
+        (deep-sleep wake / F1 / 2 s hold to forget BLE keyboards),
+        two side keys (Up / Down), and four bottom keys (Left, Right,
+        Enter, Esc).
+
+        This board has been added without on-hardware testing: pin
+        assignments come from the FreeInk SDK
+        (github.com/Free-Ink/freeink-sdk, MIT licensed),
+        docs/xteink-x4c-support.md. Grayscale / anti-aliasing
+        rendering is not implemented (matches the existing e-paper
+        boards).
+
 config DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     bool "Elecrow CrowPanel ESP32-S3 5.79\" E-Paper HMI (SSD1683 x2, 792x272)"
     depends on IDF_TARGET_ESP32S3
@@ -353,6 +378,7 @@ config DRAFTLING_DISPLAY_EPD
     default y if DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO
     default y if DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752
     default y if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default y if DRAFTLING_MODEL_XTEINK_X4_CLASSIC
     default y if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     default n
 
@@ -390,6 +416,18 @@ config DRAFTLING_DISPLAY_H752_EPD
 config DRAFTLING_DISPLAY_XTEINK_EPD
     bool
     default y if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default y if DRAFTLING_MODEL_XTEINK_X4_CLASSIC
+    default n
+
+# DRAFTLING_MODEL_XTEINK_X4 groups the two Xteink X4 boards
+# (X4 Pro and X4 Classic) that share the display_xteink_epd.cpp
+# backend, the CW2017 gauge, the SDMMC slot and the OTA partition
+# table. Code that is common to both keys off this instead of
+# testing the two model ids.
+config DRAFTLING_MODEL_XTEINK_X4
+    bool
+    default y if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default y if DRAFTLING_MODEL_XTEINK_X4_CLASSIC
     default n
 
 # DRAFTLING_DISPLAY_SSD1683 selects the from-scratch dual-controller
@@ -434,7 +472,8 @@ config DRAFTLING_DISPLAY_HAS_BACKLIGHT
     default y if DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752
     # Xteink X4 Pro: dual-channel (cool/warm) PWM front-light, both
     # channels driven identically from this single percentage since
-    # Draftling has no warm/cool color-temperature UI.
+    # Draftling has no warm/cool color-temperature UI. The X4 Classic
+    # has no front-light and is deliberately left off here.
     default y if DRAFTLING_MODEL_XTEINK_X4_PRO
     default n
 
@@ -477,6 +516,8 @@ config DRAFTLING_BACKLIGHT_MIN_PCT
     default 0 if DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO
     default 0 if DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752
     default 0 if DRAFTLING_MODEL_XTEINK_X4_PRO
+    # X4 Classic has no front-light, so DRAFTLING_DISPLAY_HAS_BACKLIGHT
+    # is off there and this value is never consulted.
     default 10
 
 # DRAFTLING_BL_DUTY_FLOOR_PCT shifts the bottom of the PWM duty
@@ -536,10 +577,10 @@ config DRAFTLING_HAS_BATTERY
     default y if DRAFTLING_MODEL_FREENOVE_FNK0104A
     default y if DRAFTLING_MODEL_FREENOVE_FNK0104B
     default y if DRAFTLING_MODEL_FREENOVE_FNK0104S
-    # Xteink X4 Pro: battery is monitored via a CW2017 fuel gauge on
-    # the shared I2C bus (driver in components/battery, gated on
-    # DRAFTLING_BATTERY_CW2017 below).
-    default y if DRAFTLING_MODEL_XTEINK_X4_PRO
+    # Xteink X4 Pro / X4 Classic: battery is monitored via a CW2017
+    # fuel gauge on the shared I2C bus (driver in components/battery,
+    # gated on DRAFTLING_BATTERY_CW2017 below).
+    default y if DRAFTLING_MODEL_XTEINK_X4
     default n
 
 # Selects the CW2017 fuel-gauge backend in components/battery/
@@ -550,7 +591,7 @@ config DRAFTLING_HAS_BATTERY
 # backend.
 config DRAFTLING_BATTERY_CW2017
     bool
-    default y if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default y if DRAFTLING_MODEL_XTEINK_X4
     default n
 
 # Selects the BQ27220 fuel-gauge backend in components/battery/
@@ -710,8 +751,8 @@ config DRAFTLING_SD_SDMMC
     default y if DRAFTLING_MODEL_FREENOVE_FNK0104A
     default y if DRAFTLING_MODEL_FREENOVE_FNK0104B
     default y if DRAFTLING_MODEL_FREENOVE_FNK0104S
-    # Xteink X4 Pro: on-board MicroSD wired to SDMMC 1-bit.
-    default y if DRAFTLING_MODEL_XTEINK_X4_PRO
+    # Xteink X4 Pro / X4 Classic: on-board MicroSD wired to SDMMC 1-bit.
+    default y if DRAFTLING_MODEL_XTEINK_X4
     default n
 
 # DRAFTLING_WAKEUP_GPIO is the per-board RTC-capable GPIO used as
@@ -748,8 +789,9 @@ config DRAFTLING_WAKEUP_GPIO
     default 0  if DRAFTLING_MODEL_FREENOVE_FNK0104A
     default 0  if DRAFTLING_MODEL_FREENOVE_FNK0104B
     default 0  if DRAFTLING_MODEL_FREENOVE_FNK0104S
-    # Xteink X4 Pro: Power button on GPIO3 (active-low, RTC-capable).
-    default 3  if DRAFTLING_MODEL_XTEINK_X4_PRO
+    # Xteink X4 Pro / X4 Classic: Power button on GPIO3 (active-low,
+    # RTC-capable).
+    default 3  if DRAFTLING_MODEL_XTEINK_X4
     # Elecrow CrowPanel 5.79" E-Paper HMI: Menu button on GPIO2
     # (active-low, RTC-capable).
     default 2  if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
@@ -1013,7 +1055,7 @@ config DRAFTLING_DISPLAY_WIDTH
     default 320 if DRAFTLING_MODEL_FREENOVE_FNK0104A
     default 320 if DRAFTLING_MODEL_FREENOVE_FNK0104B
     default 480 if DRAFTLING_MODEL_FREENOVE_FNK0104S
-    default 800 if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default 800 if DRAFTLING_MODEL_XTEINK_X4
     default 792 if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     help
         Display width in pixels (derived). Driven by the hardware-model
@@ -1035,7 +1077,7 @@ config DRAFTLING_DISPLAY_HEIGHT
     default 240 if DRAFTLING_MODEL_FREENOVE_FNK0104A
     default 240 if DRAFTLING_MODEL_FREENOVE_FNK0104B
     default 320 if DRAFTLING_MODEL_FREENOVE_FNK0104S
-    default 480 if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default 480 if DRAFTLING_MODEL_XTEINK_X4
     default 272 if DRAFTLING_MODEL_ELECROW_CROWPANEL_579
     help
         Display height in pixels (derived). Driven by the hardware-model
@@ -1075,10 +1117,11 @@ config DRAFTLING_DISPLAY_ROTATE_ANGLE
 # a quarter turn clockwise; 270 turns it the other way. Non-prompted
 # derived int so the per-board value tracks the hardware-model choice.
 # The Xteink X4 Pro's enclosure reads better with portrait rotated the
-# opposite way from the default.
+# opposite way from the default; the X4 Classic is assumed to match
+# (its pocket enclosure is the same family; not verified on hardware).
 config DRAFTLING_DISPLAY_PORTRAIT_EXTRA_ROTATE
     int
-    default 270 if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default 270 if DRAFTLING_MODEL_XTEINK_X4
     default 90
 
 # DRAFTLING_DISPLAY_HIDPI -- high-density panel that renders the UI
@@ -1101,7 +1144,7 @@ config DRAFTLING_DISPLAY_HIDPI
     default y if DRAFTLING_MODEL_M5STACK_TAB5
     default y if DRAFTLING_MODEL_SUNTON_8048S070
     default y if DRAFTLING_MODEL_SUNTON_8048S043
-    default y if DRAFTLING_MODEL_XTEINK_X4_PRO
+    default y if DRAFTLING_MODEL_XTEINK_X4
     default y if DRAFTLING_MODEL_WAVESHARE_TOUCH_LCD_7
     default n
 config DRAFTLING_EPD_FULL_REFRESH_INTERVAL

--- a/firmware/main/app_config.h
+++ b/firmware/main/app_config.h
@@ -73,6 +73,8 @@
 #include "boards/freenove_fnk0104s.h"
 #elif defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO)
 #include "boards/xteink_x4_pro.h"
+#elif defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
+#include "boards/xteink_x4_classic.h"
 #elif defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
 #include "boards/elecrow_crowpanel_579.h"
 #else

--- a/firmware/main/boards/xteink_x4_classic.h
+++ b/firmware/main/boards/xteink_x4_classic.h
@@ -1,0 +1,96 @@
+#pragma once
+/* ----- Xteink X4 Classic (also marketed "X4 v2") -----
+ *
+ * ESP32-S3 e-reader, the buttons-only sibling of the Xteink X4 Pro
+ * (boards/xteink_x4_pro.h). It shares the X4 Pro's ESP32-S3 module,
+ * the 4.26" 800x480 e-paper glass and the whole
+ * components/display/display_xteink_epd.cpp controller stack (the
+ * panel still ships with one of SSD1677 / UC8179 / UC8279 depending
+ * on the production run, auto-detected at boot), plus the CW2017 I2C
+ * fuel gauge and the SDMMC 1-bit MicroSD slot.
+ *
+ * What it does NOT have, compared with the X4 Pro:
+ *   - no GT911 capacitive touch  (CONFIG_DRAFTLING_TOUCHSCREEN off)
+ *   - no front-light             (CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT off)
+ * The GPIOs the X4 Pro spends on touch power-enable (GPIO2) and the
+ * warm/cool front-light PWM (GPIO8/GPIO9) are wired to four extra
+ * front buttons here instead, and the panel's DC/RST/BUSY lines land
+ * on different GPIOs than the X4 Pro (SCLK/MOSI/CS are the same) --
+ * see components/display/display_xteink_epd.cpp.
+ *
+ * Pin assignments come from the FreeInk SDK
+ * (https://github.com/Free-Ink/freeink-sdk, MIT licensed),
+ * docs/xteink-x4c-support.md, which reverse-engineered the OEM
+ * firmware. This board has NOT been tested on physical hardware; see
+ * HARDWARE.md.
+ *
+ * Included by main/app_config.h when
+ * CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC is selected.
+ */
+
+#define BOARD_NAME      "Xteink X4 Classic"
+
+/* Master peripheral-rail latch, driven HIGH once at boot (same as the
+ * X4 Pro's XTEINK_POWER_LATCH_PIN -- GPIO1 is the panel/SD/peripheral
+ * power rail; without it the e-paper and SD slot stay unpowered).
+ * Not a battery/MCU power switch: there is no hardware latch that can
+ * fully power this board off from software, so a Power-button press
+ * enters deep sleep (see the generic wakeup handling in main.cpp). */
+#define XTEINK_POWER_LATCH_PIN 1
+
+/* E-paper panel SPI bus (SCLK=12, MOSI=11, CS=13) and its control
+ * lines (DC=14, RST=10, BUSY=18 -- different GPIOs from the X4 Pro)
+ * are hard-coded inside components/display/display_xteink_epd.cpp,
+ * matching the convention of display_ili9341.cpp / display_h752.cpp:
+ * that backend is used by exactly the X4 Pro and X4 Classic, and it
+ * picks the pin set at build time on the model symbol. */
+
+/* Shared I2C bus: CW2017 fuel gauge (0x63). The OEM also wires a
+ * BM8563 RTC (0x51) and a QMI8658 IMU (0x6B) here; Draftling uses
+ * neither. */
+#define I2C_SDA_PIN     39
+#define I2C_SCL_PIN     38
+
+/* CW2017 fuel gauge, on the shared I2C bus above. No charger IC on
+ * this bus, so charging state is reported as unknown. */
+#define CW2017_I2C_ADDR 0x63
+#define BATT_ADC_PIN    -1
+#define BATT_EN_PIN     -1
+#define BATT_DIVIDER    1
+
+/* On-board MicroSD, SDMMC 1-bit mode. Power-enable line (active-low)
+ * on GPIO6 -- note this differs from the X4 Pro (GPIO5, which is a
+ * button here). main.cpp power-cycles it (HIGH ~80 ms, then LOW and
+ * held LOW while mounted) before sd_card_init(). */
+#define SD_CLK_PIN      41
+#define SD_CMD_PIN      42
+#define SD_D0_PIN       40
+#define SD_POWER_EN_PIN 6
+
+/* Eight discrete buttons, all active-low on RTC-capable GPIOs, read
+ * with the ESP32-S3 internal pull-ups. Draftling drives the editor
+ * entirely from these (no touch, and no keyboard until BLE pairs) --
+ * see xteink_x4_classic_*_init() in main.cpp:
+ *
+ *   Power  (GPIO3)  deep-sleep wake source; short press = F1
+ *                   (open/close Settings), 2 s hold = forget BLE
+ *                   keyboards -- same convention as the CrowPanel
+ *                   5.79" Menu button.
+ *   Left   (GPIO0)  side key   -> Up arrow      (GPIO0 is a boot
+ *                                strap pin; fine as long as it is
+ *                                not held during reset)
+ *   Right  (GPIO7)  side key   -> Down arrow
+ *   B.Left (GPIO5)  bottom key -> Left arrow
+ *   B.Right(GPIO2)  bottom key -> Right arrow
+ *   Confirm(GPIO8)  bottom key -> Enter
+ *   Back   (GPIO9)  bottom key -> Esc
+ *
+ * (GPIO4 is a further discrete input on the OEM board that the SDK
+ * does not use; Draftling ignores it too.) */
+#define BTN_LEFT_PIN         0
+#define BTN_RIGHT_PIN        7
+#define BTN_BOTTOM_LEFT_PIN  5
+#define BTN_BOTTOM_RIGHT_PIN 2
+#define BTN_CONFIRM_PIN      8
+#define BTN_BACK_PIN         9
+#define WAKEUP_GPIO_NUM      3

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -715,6 +715,20 @@ static void pre_sleep_xteink_x4_pro_deinit(void)
 }
 #endif /* CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO */
 
+#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
+static void pre_sleep_xteink_x4_classic_deinit(void)
+{
+    ESP_LOGI(TAG, "Pre-sleep: Xteink X4 Classic peripheral teardown");
+
+    /* Same as the X4 Pro teardown minus touchscreen_sleep() -- this
+     * board has no touch controller. */
+    pre_sleep_autosave();
+    (void)sd_card_deinit();
+    display_deep_sleep_prepare();
+    gpio_deep_sleep_hold_en();
+}
+#endif /* CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC */
+
 #if defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
 static void pre_sleep_crowpanel_579_deinit(void)
 {
@@ -918,6 +932,143 @@ static void xteink_x4_pro_btn_init(void)
 }
 #endif /* CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO */
 
+#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
+/* ---- Xteink X4 Classic buttons ----
+ *
+ * The X4 Classic has no touchscreen, so its eight buttons are the
+ * only way to drive the editor until a BLE keyboard pairs -- the same
+ * situation as the Elecrow CrowPanel 5.79", and handled the same way.
+ *
+ * Power (WAKEUP_GPIO_NUM, also the deep-sleep wake source) doubles as
+ * F1 on a short press (open/close the Settings menu) and forgets every
+ * stored BLE keyboard bond on a 2 s hold. The remaining six keys are
+ * injected on release as Up / Down (side keys) and Left / Right /
+ * Enter / Esc (bottom keys), giving full menu + editor navigation.
+ *
+ * Debounce: 5 consecutive BTN_POLL_PERIOD_MS samples, matching the
+ * CrowPanel -- an e-paper partial refresh's boost-converter transient
+ * can dip a weakly-pulled button line enough to read as a brief press,
+ * and a refresh follows every keystroke. */
+#define XTEINK_X4C_DEBOUNCE_SAMPLES 5
+#define XTEINK_X4C_LONG_PRESS_TICKS BTN_LONG_PRESS_TICKS
+
+static void xteink_x4_classic_inject_key(uint8_t keycode)
+{
+    kb_event_t ev = {};
+    ev.keycode = keycode;
+    ev.pressed = true;
+    editor_ui_handle_key(&ev);
+    ev.pressed = false;
+    editor_ui_handle_key(&ev);
+}
+
+static void xteink_x4_classic_power_key_poll_cb(void *arg)
+{
+    (void)arg;
+    static bool down             = false;
+    static int  stable           = 0;
+    static int  hold_ticks       = 0;
+    static bool long_press_fired = false;
+
+    bool raw_down = gpio_get_level((gpio_num_t)WAKEUP_GPIO_NUM) == 0;
+
+    if (raw_down == down) {
+        if (down) {
+            hold_ticks++;
+            if (!long_press_fired && hold_ticks >= XTEINK_X4C_LONG_PRESS_TICKS) {
+                long_press_fired = true;
+                ESP_LOGI(TAG, "X4 Classic Power button: 2 s long press -- "
+                              "forgetting all keyboards (GPIO%d)",
+                         WAKEUP_GPIO_NUM);
+                ble_keyboard_forget_all();
+            }
+        }
+        stable = 0;
+        return;
+    }
+
+    if (++stable < XTEINK_X4C_DEBOUNCE_SAMPLES) return;
+
+    stable = 0;
+    down = raw_down;
+
+    if (down) {
+        hold_ticks       = 0;
+        long_press_fired = false;
+    } else {
+        if (!long_press_fired) {
+            xteink_x4_classic_inject_key(KB_KEY_F1);
+        }
+        hold_ticks       = 0;
+        long_press_fired = false;
+    }
+}
+
+static void xteink_x4_classic_nav_poll_cb(void *arg)
+{
+    (void)arg;
+    static const struct { int pin; uint8_t keycode; } kButtons[] = {
+        { BTN_LEFT_PIN,         KB_KEY_UP },
+        { BTN_RIGHT_PIN,        KB_KEY_DOWN },
+        { BTN_BOTTOM_LEFT_PIN,  KB_KEY_LEFT },
+        { BTN_BOTTOM_RIGHT_PIN, KB_KEY_RIGHT },
+        { BTN_CONFIRM_PIN,      KB_KEY_ENTER },
+        { BTN_BACK_PIN,         KB_KEY_ESCAPE },
+    };
+    static bool down[6]   = { false, false, false, false, false, false };
+    static int  stable[6] = { 0, 0, 0, 0, 0, 0 };
+
+    for (int i = 0; i < 6; i++) {
+        bool raw_down = gpio_get_level((gpio_num_t)kButtons[i].pin) == 0;
+        if (raw_down == down[i]) {
+            stable[i] = 0;
+            continue;
+        }
+        if (++stable[i] < XTEINK_X4C_DEBOUNCE_SAMPLES) continue;
+        stable[i] = 0;
+        down[i] = raw_down;
+        if (!down[i]) {
+            xteink_x4_classic_inject_key(kButtons[i].keycode);
+        }
+    }
+}
+
+static void xteink_x4_classic_btn_init(void)
+{
+    gpio_config_t g = {};
+    g.intr_type    = GPIO_INTR_DISABLE;
+    g.mode         = GPIO_MODE_INPUT;
+    g.pin_bit_mask = (1ULL << WAKEUP_GPIO_NUM) |
+                     (1ULL << BTN_LEFT_PIN) | (1ULL << BTN_RIGHT_PIN) |
+                     (1ULL << BTN_BOTTOM_LEFT_PIN) | (1ULL << BTN_BOTTOM_RIGHT_PIN) |
+                     (1ULL << BTN_CONFIRM_PIN) | (1ULL << BTN_BACK_PIN);
+    g.pull_up_en   = GPIO_PULLUP_ENABLE;
+    g.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    gpio_config(&g);
+
+    esp_timer_create_args_t pargs = {};
+    pargs.callback = xteink_x4_classic_power_key_poll_cb;
+    pargs.name     = "x4c_power";
+    esp_timer_handle_t pt = NULL;
+    ESP_ERROR_CHECK(esp_timer_create(&pargs, &pt));
+    ESP_ERROR_CHECK(esp_timer_start_periodic(pt, (uint64_t)BTN_POLL_PERIOD_MS * 1000));
+
+    esp_timer_create_args_t nargs = {};
+    nargs.callback = xteink_x4_classic_nav_poll_cb;
+    nargs.name     = "x4c_nav";
+    esp_timer_handle_t nt = NULL;
+    ESP_ERROR_CHECK(esp_timer_create(&nargs, &nt));
+    ESP_ERROR_CHECK(esp_timer_start_periodic(nt, (uint64_t)BTN_POLL_PERIOD_MS * 1000));
+
+    ESP_LOGI(TAG, "Xteink X4 Classic button pollers started "
+                  "(Power=GPIO%d; Up=GPIO%d Down=GPIO%d Left=GPIO%d "
+                  "Right=GPIO%d Enter=GPIO%d Esc=GPIO%d)",
+             WAKEUP_GPIO_NUM, BTN_LEFT_PIN, BTN_RIGHT_PIN,
+             BTN_BOTTOM_LEFT_PIN, BTN_BOTTOM_RIGHT_PIN,
+             BTN_CONFIRM_PIN, BTN_BACK_PIN);
+}
+#endif /* CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC */
+
 #if defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
 /* ---- CrowPanel 5.79in Menu button + Back button/dial switch ----
  *
@@ -1092,7 +1243,8 @@ static void crowpanel_nav_init(void)
  * enabled (the same electrical assumption the standby component makes
  * when it arms the EXT0 deep-sleep wake source on GPIO 0 / 18). */
 #if !defined(CONFIG_DRAFTLING_MODEL_LILYGO_T5_EPD_S3_PRO_H752) && \
-    !defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
+    !defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579) && \
+    !defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
 
 /* Poll period BTN_POLL_PERIOD_MS ms; BTN_LONG_PRESS_TICKS ticks = 2 s hold. */
 #define WAKEUP_BTN_LONG_PRESS_TICKS BTN_LONG_PRESS_TICKS
@@ -1332,19 +1484,19 @@ extern "C" void app_main(void)
      * those bring-up paths see fresh, un-latched pads. */
     t5_release_held_gpios_after_wake();
 #endif
-#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO)
-    /* pre_sleep_xteink_x4_pro_deinit() calls gpio_deep_sleep_hold_en()
+#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4)
+    /* pre_sleep_xteink_x4_*_deinit() calls gpio_deep_sleep_hold_en()
      * before deep sleep, which on the ESP32-S3 keeps the digital GPIO
      * output levels latched into the next startup -- and stays latched
      * until gpio_deep_sleep_hold_dis() is called. Release it here, on
      * every boot, so the display / touch / SD bring-up below can drive
      * the peripheral-rail and power-enable pads freely (in particular
-     * the GT911 power-cycle further down). A no-op if nothing was
-     * held. */
+     * the X4 Pro's GT911 power-cycle further down). A no-op if nothing
+     * was held. */
     gpio_deep_sleep_hold_dis();
 
-    /* Master peripheral-rail latch. Must be driven HIGH before any
-     * SPI/display/SD bring-up -- without it, the e-paper panel rail
+    /* Master peripheral-rail latch (GPIO1). Must be driven HIGH before
+     * any SPI/display/SD bring-up -- without it, the e-paper panel rail
      * and the SD slot both stay unpowered. No I2C expander involved
      * (unlike the components/power TCA9554 latch on the Touch-LCD-3.49). */
     {
@@ -1355,7 +1507,8 @@ extern "C" void app_main(void)
         gpio_config(&g);
         gpio_set_level((gpio_num_t)XTEINK_POWER_LATCH_PIN, 1);
     }
-
+#endif
+#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO)
     /* Full GT911 power-cycle + hardware reset with the datasheet
      * address-select timing. Done HERE, before the shared I2C bus is
      * created below, and `tcfg.rst` is passed as -1 so touchscreen_init()
@@ -1633,10 +1786,12 @@ extern "C" void app_main(void)
      * ignored. */
     display_init(-1, -1, -1, -1, -1, -1, DISPLAY_WIDTH, DISPLAY_HEIGHT);
 #elif defined(CONFIG_DRAFTLING_DISPLAY_XTEINK_EPD)
-    /* Xteink X4 Pro SPI e-paper backend. Owns all panel GPIOs
-     * internally (see main/boards/xteink_x4_pro.h) and auto-detects
-     * which of three possible controllers (SSD1677, UC8179, UC8279)
-     * the panel is wired to. Pin parameters are ignored. */
+    /* Xteink X4 Pro / X4 Classic SPI e-paper backend. Owns all panel
+     * GPIOs internally (the pin set is picked at build time on the
+     * model symbol -- see components/display/display_xteink_epd.cpp)
+     * and auto-detects which of three possible controllers (SSD1677,
+     * UC8179, UC8279) the panel is wired to. Pin parameters are
+     * ignored. */
     display_init(-1, -1, -1, -1, -1, -1, DISPLAY_WIDTH, DISPLAY_HEIGHT);
 #elif defined(CONFIG_DRAFTLING_DISPLAY_MIPI_DSI)
     /* M5Stack Tab5 MIPI-DSI panel. All panel GPIOs, the MIPI-DSI
@@ -1759,10 +1914,11 @@ extern "C" void app_main(void)
         ESP_LOGW(TAG, "INA226 init failed; battery indicator disabled");
     }
 #elif defined(CONFIG_DRAFTLING_BATTERY_CW2017)
-    /* Xteink X4 Pro: CW2017 fuel gauge on the shared I2C bus created
-     * above (also carrying the GT911 touch controller). No charger
-     * IC on this bus, so battery_read_charging() always reports
-     * "unknown" for this backend. */
+    /* Xteink X4 Pro / X4 Classic: CW2017 fuel gauge on the shared I2C
+     * bus created above (which also carries the GT911 touch controller
+     * on the X4 Pro). No charger IC on this bus, so
+     * battery_read_charging() always reports "unknown" for this
+     * backend. */
     if (battery_init_cw2017(shared_i2c_bus) != 0) {
         ESP_LOGW(TAG, "CW2017 fuel gauge init failed; battery indicator disabled");
     }
@@ -1840,14 +1996,22 @@ extern "C" void app_main(void)
      * is the actual fix.) */
     bool sd_lvgl_held = draftling_lvgl_port_lock(-1);
 #endif
-#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO)
-    /* SD slot power-enable, active-low. Drive it before mounting. */
+#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4)
+    /* SD slot power-enable, active-low. Drive it before mounting.
+     * X4 Pro: GPIO5, driven straight LOW. X4 Classic: GPIO6, which
+     * wants a power-cycle first (HIGH ~80 ms to drain the rail, then
+     * LOW and held LOW while the card is mounted -- FreeInk SDK
+     * SdmmcBlockDevice). */
     {
         gpio_config_t sd_pwr = {};
         sd_pwr.intr_type    = GPIO_INTR_DISABLE;
         sd_pwr.mode         = GPIO_MODE_OUTPUT;
         sd_pwr.pin_bit_mask = (1ULL << SD_POWER_EN_PIN);
         gpio_config(&sd_pwr);
+#if defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
+        gpio_set_level((gpio_num_t)SD_POWER_EN_PIN, 1);
+        vTaskDelay(pdMS_TO_TICKS(80));
+#endif
         gpio_set_level((gpio_num_t)SD_POWER_EN_PIN, 0);
     }
 #endif
@@ -2356,6 +2520,8 @@ extern "C" void app_main(void)
     standby_set_pre_sleep_cb(pre_sleep_tab5_deinit);
 #elif defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_PRO)
     standby_set_pre_sleep_cb(pre_sleep_xteink_x4_pro_deinit);
+#elif defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
+    standby_set_pre_sleep_cb(pre_sleep_xteink_x4_classic_deinit);
 #elif defined(CONFIG_DRAFTLING_MODEL_ELECROW_CROWPANEL_579)
     standby_set_pre_sleep_cb(pre_sleep_crowpanel_579_deinit);
 #else
@@ -2379,6 +2545,11 @@ extern "C" void app_main(void)
      * the rest of menu navigation once it is open. */
     crowpanel_menu_key_init();
     crowpanel_nav_init();
+#elif defined(CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC)
+    /* Power button (GPIO3) = F1 on short press, forget all keyboards
+     * on 2 s long press. Six nav keys (Up/Down/Left/Right/Enter/Esc)
+     * drive the rest -- same buttons-only model as the CrowPanel. */
+    xteink_x4_classic_btn_init();
 #else
     /* Generic wakeup-button long-press monitor: hold 2 s to forget
      * all stored BLE keyboard pairings and start a fresh scan (and,

--- a/firmware/partitions_xteink_x4_classic.csv
+++ b/firmware/partitions_xteink_x4_classic.csv
@@ -1,0 +1,28 @@
+# Xteink X4 Classic (X4 v2) -- partition table
+#
+# Identical layout to partitions_xteink_x4_pro.csv (see the rationale
+# there): the standard ESP-IDF dual-OTA layout -- an "otadata"
+# partition plus two app slots (ota_0 / ota_1). Draftling runs from
+# ota_0; ota_1 is left empty.
+#
+# Why this board is different from the single-"factory" default: the
+# X4 Classic, like the X4 Pro, ships with an OTA-capable partition
+# table, and both the stock Xteink firmware and the third-party
+# "Crosspoint" firmware are installed by OTA updaters that abort
+# against a table with no "otadata" partition ("Partition table has no
+# otadata partition"). Keeping an OTA layout here means the device can
+# be returned to stock, or moved to Crosspoint, without having to
+# re-flash a partition table over USB first.
+#
+# The app slots (0x7F0000 = ~8.1 MB each) are far larger than
+# Draftling needs (~2.3 MB), so a stock or Crosspoint image fits in
+# either slot too. "nvs" is 0x4000 (16 KB -- the ESP-IDF two-OTA
+# default) so that "otadata" and "phy_init" still fit below the 64
+# KB-aligned ota_0 offset.
+#
+# Name,   Type, SubType,  Offset,    Size,      Flags
+nvs,      data, nvs,      0x9000,    0x4000,
+otadata,  data, ota,      0xd000,    0x2000,
+phy_init, data, phy,      0xf000,    0x1000,
+ota_0,    app,  ota_0,    0x10000,   0x7F0000,
+ota_1,    app,  ota_1,    0x800000,  0x7F0000,

--- a/firmware/sdkconfig.defaults.xteink_x4_classic
+++ b/firmware/sdkconfig.defaults.xteink_x4_classic
@@ -1,0 +1,13 @@
+# CMakePresets.json board defaults: Xteink X4 Classic (X4 v2)
+# Sets the hardware model and IDF target used by the "xteink_x4_classic" preset.
+
+CONFIG_IDF_TARGET="esp32s3"
+CONFIG_DRAFTLING_MODEL_XTEINK_X4_CLASSIC=y
+
+# Dual-OTA partition table (with an "otadata" partition), same as the
+# X4 Pro: the stock Xteink firmware and the third-party Crosspoint
+# firmware are installed by OTA updaters that refuse to run without an
+# "otadata" partition, so keeping an OTA layout lets the device be
+# returned to stock or moved to Crosspoint without first re-flashing a
+# partition table over USB. See partitions_xteink_x4_classic.csv.
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions_xteink_x4_classic.csv"


### PR DESCRIPTION
## What

Adds the **Xteink X4 Classic** (also marketed as **X4 v2**) as a new board: the buttons-only, no-front-light sibling of the Xteink X4 Pro.

The two boards share the ESP32-S3 module, the 4.26" 800×480 e-paper glass and the whole `display_xteink_epd.cpp` controller stack (SSD1677 / UC8179 / UC8279 auto-detected at boot), the CW2017 fuel gauge and the SDMMC card slot — so most of this is a straight reuse of the X4 Pro path behind a new derived Kconfig symbol `DRAFTLING_MODEL_XTEINK_X4`.

## Board-specific differences

All from the [FreeInk SDK](https://github.com/Free-Ink/freeink-sdk) (`docs/xteink-x4c-support.md`), which reverse-engineered the OEM firmware:

| | X4 Pro | X4 Classic |
|---|---|---|
| Touch | GT911 | **none** (`CONFIG_DRAFTLING_TOUCHSCREEN` off) |
| Front-light | dual warm/cool PWM | **none** (`CONFIG_DRAFTLING_DISPLAY_HAS_BACKLIGHT` off) |
| Panel DC / RST / BUSY | 18 / 14 / 6 | **14 / 10 / 18** (SCLK/MOSI/CS unchanged) |
| UC8279 init | programs PLL (0x30) | omits it |
| SD power-enable | GPIO5, driven LOW | **GPIO6**, power-cycled (HIGH ~80 ms → LOW) |
| Buttons | Left/Right + Power | Power + **6 nav keys** |

The GT911 power-cycle block and the LEDC front-light code compile out for the X4 Classic; `display_xteink_epd.cpp` gains a no-op `display_set_backlight()` the same way `display_ssd1683.cpp` has one.

### Input

No touch and no keyboard until BLE pairs, so the eight buttons drive the whole editor — same model as the Elecrow CrowPanel 5.79":

- **Power** (GPIO3, deep-sleep wake): short press → F1 (open/close Settings), 2 s hold → forget BLE keyboards
- **Side keys** (GPIO0 / GPIO7) → Up / Down
- **Bottom keys** (GPIO5 / GPIO2 / GPIO8 / GPIO9) → Left / Right / Enter / Esc

## Files

New: `firmware/main/boards/xteink_x4_classic.h`, `firmware/sdkconfig.defaults.xteink_x4_classic`, `firmware/partitions_xteink_x4_classic.csv` (dual-OTA, identical layout to the X4 Pro's so the stock / Crosspoint OTA updaters can reinstall), CMake preset `xteink_x4_classic`.

Touched: `Kconfig.projbuild`, `app_config.h`, `main.cpp`, `display_xteink_epd.cpp`, docs (HARDWARE.md, AGENTS.md, CHANGELOG.md, README.md, BUILDING.md).

## Testing

- `idf.py --preset xteink_x4_classic build` ✅
- `idf.py --preset xteink_x4_pro build` ✅ (no regression)
- `idf.py --preset elecrow_crowpanel_579 reconfigure` ✅ (derived symbol doesn't leak)

**This board has NOT been tested on physical hardware** — same status as the initial X4 Pro / Elecrow ports. See HARDWARE.md.

## Follow-up (not in this PR)

The web-flasher `manifest.json` entry on the `_flasher` branch, plus prebuilt binaries + `ota_data_initial.bin`, come after a tagged release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)